### PR TITLE
fix compilation

### DIFF
--- a/cartagen-appli/pom.xml
+++ b/cartagen-appli/pom.xml
@@ -21,36 +21,56 @@
       <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
-	<dependency>
-       <groupId>${project.groupId}</groupId>
-       <artifactId>cartagen-core</artifactId>
-       <version>${project.version}</version>
-    </dependency>
-	<dependency>
-       <groupId>${project.groupId}</groupId>
-       <artifactId>geoxygene-appli</artifactId>
-       <version>${geoxygene.version}</version>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>cartagen-core</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
-		<groupId>jgraph</groupId>
-		<artifactId>jgraph</artifactId>
-		<version>5.13.0.0</version>
-	</dependency>
-	<dependency>
-		<groupId>net.sourceforge.jexcelapi</groupId>
-		<artifactId>jxl</artifactId>
-		<version>2.6.12</version>
-	</dependency>
-	<dependency>
-		<groupId>twak</groupId>
-		<artifactId>campskeleton</artifactId>
-		<version>1.0</version>
-		<scope>compile</scope>
-	</dependency>
-	<dependency>
-			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
-			<version>42.2.24.jre7</version>
-		</dependency>	
+      <groupId>${project.groupId}</groupId>
+      <artifactId>geoxygene-appli</artifactId>
+      <version>${geoxygene.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>carto</artifactId>
+      <version>${geoxygene.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>ontology</artifactId>
+      <version>${geoxygene.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>jgraph</groupId>
+      <artifactId>jgraph</artifactId>
+      <version>5.13.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.jgoodies</groupId>
+      <artifactId>jgoodies-forms</artifactId>
+      <version>1.6.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.lwjgl.lwjgl</groupId>
+      <artifactId>lwjgl</artifactId>
+      <version>2.9.1</version>
+    </dependency>
+    <dependency>
+      <groupId>net.sourceforge.jexcelapi</groupId>
+      <artifactId>jxl</artifactId>
+      <version>2.6.12</version>
+    </dependency>
+    <dependency>
+      <groupId>twak</groupId>
+      <artifactId>campskeleton</artifactId>
+      <version>1.0</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.2.24.jre7</version>
+    </dependency>
   </dependencies>
 </project>

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/agents/FrameInfoAgent.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/agents/FrameInfoAgent.java
@@ -25,7 +25,8 @@ import javax.swing.event.TreeSelectionListener;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.TreeSelectionModel;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.agent.GeographicObjectAgentGeneralisation;
 import fr.ign.cogit.geoxygene.contrib.agents.state.AgentState;
@@ -37,7 +38,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.state.GeographicAgentState;
  */
 public class FrameInfoAgent extends JFrame {
   private static final long serialVersionUID = 1L;
-  static final Logger logger = Logger.getLogger(FrameInfoAgent.class.getName());
+  static final Logger logger = LogManager.getLogger(FrameInfoAgent.class.getName());
 
   private GeographicObjectAgentGeneralisation agentGeo = null;
 

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/agents/PanelVisuInfoAgent.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/agents/PanelVisuInfoAgent.java
@@ -5,7 +5,8 @@ package fr.ign.cogit.cartagen.appli.agents;
 
 import java.awt.Color;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.state.MicroAgentState;
 import fr.ign.cogit.geoxygene.appli.layer.LayerViewAwtPanel;
@@ -20,7 +21,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.state.MesoAgentState;
  */
 public class PanelVisuInfoAgent extends LayerViewAwtPanel {
   private static final long serialVersionUID = -5037001262393524360L;
-  private final static Logger logger = Logger
+  private final static Logger logger = LogManager
       .getLogger(PanelVisuInfoAgent.class.getName());
 
   /**

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/CartAGenApplicationAgent.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/CartAGenApplicationAgent.java
@@ -18,7 +18,8 @@ import javax.swing.JMenu;
 import javax.swing.JPanel;
 import javax.swing.JSplitPane;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.appli.core.geoxygene.CartAGenPlugin;
 import fr.ign.cogit.geoxygene.appli.GeOxygeneApplication;
@@ -33,7 +34,7 @@ import fr.ign.cogit.geoxygene.spatial.geomengine.GeometryEngine;
  */
 public class CartAGenApplicationAgent extends GeOxygeneApplication implements AgentObserver {
     @SuppressWarnings("unused")
-    private static final Logger logger = Logger.getLogger(CartAGenApplicationAgent.class);
+    private static final Logger logger = LogManager.getLogger(CartAGenApplicationAgent.class);
 
     private boolean slowMotion = false;
 

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/CartAGenApplicationNoAgent.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/CartAGenApplicationNoAgent.java
@@ -16,7 +16,8 @@ import java.util.List;
 import javax.swing.JFrame;
 import javax.swing.JMenu;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.appli.core.geoxygene.CartAGenPlugin;
 import fr.ign.cogit.geoxygene.appli.GeOxygeneApplication;
@@ -29,7 +30,7 @@ import fr.ign.cogit.geoxygene.spatial.geomengine.GeometryEngine;
  * @author Charlotte Hoarau
  */
 public class CartAGenApplicationNoAgent extends GeOxygeneApplication {
-    private static final Logger logger = Logger.getLogger(CartAGenApplicationNoAgent.class);
+    private static final Logger logger = LogManager.getLogger(CartAGenApplicationNoAgent.class);
 
     private CartAGenApplicationNoAgent() {
         super("CartAGen-GeOxygene");

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/GeneralisationMenuAgentComplement.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/GeneralisationMenuAgentComplement.java
@@ -11,7 +11,8 @@ import javax.swing.JMenu;
 import javax.swing.JMenuBar;
 import javax.swing.JMenuItem;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.AgentUtil;
 import fr.ign.cogit.cartagen.agents.core.agent.urban.BlockAgent;
@@ -40,7 +41,7 @@ import fr.ign.cogit.geoxygene.appli.MainFrameMenuBar;
  * @author julien Gaffuri 6 mars 2009
  */
 public class GeneralisationMenuAgentComplement {
-    static Logger logger = Logger.getLogger(GeneralisationMenuAgentComplement.class.getName());
+    static Logger logger = LogManager.getLogger(GeneralisationMenuAgentComplement.class.getName());
 
     /**
      * @return

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/GeneralisationRightPanelAgentComplement.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/GeneralisationRightPanelAgentComplement.java
@@ -21,7 +21,8 @@ import javax.swing.JScrollPane;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.AgentGeneralisationScheduler;
 import fr.ign.cogit.cartagen.agents.core.AgentSpecifications;
@@ -51,7 +52,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.agent.IAgent;
  */
 public class GeneralisationRightPanelAgentComplement implements AgentObserver {
 
-	static Logger logger = Logger.getLogger(GeneralisationRightPanelAgentComplement.class.getName());
+	static Logger logger = LogManager.getLogger(GeneralisationRightPanelAgentComplement.class.getName());
 
 	static Logger getLogger() {
 		return GeneralisationRightPanelAgentComplement.logger;

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/actions/GeneReliefGAELAgentAction.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/actions/GeneReliefGAELAgentAction.java
@@ -5,7 +5,8 @@ import java.awt.event.ActionEvent;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.AgentGeneralisationScheduler;
 import fr.ign.cogit.cartagen.agents.core.AgentUtil;
@@ -21,7 +22,7 @@ public class GeneReliefGAELAgentAction extends AbstractAction {
      * 
      */
     private static final long serialVersionUID = 1L;
-    private static Logger logger = Logger.getLogger(GeneReliefGAELAgentAction.class.getName());
+    private static Logger logger = LogManager.getLogger(GeneReliefGAELAgentAction.class.getName());
 
     @Override
     public void actionPerformed(ActionEvent arg0) {

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/actions/RunOnSelectionAction.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/actions/RunOnSelectionAction.java
@@ -7,7 +7,8 @@ import java.util.HashSet;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.AgentGeneralisationScheduler;
 import fr.ign.cogit.cartagen.agents.core.AgentUtil;
@@ -25,7 +26,7 @@ public class RunOnSelectionAction extends AbstractAction {
      * 
      */
     private static final long serialVersionUID = 1L;
-    private static Logger logger = Logger.getLogger(RunOnSelectionAction.class.getName());
+    private static Logger logger = LogManager.getLogger(RunOnSelectionAction.class.getName());
 
     @Override
     public void actionPerformed(ActionEvent arg0) {

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/geoxygene/AlgorithmsMenu.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/geoxygene/AlgorithmsMenu.java
@@ -23,7 +23,7 @@ import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 
-import com.vividsolutions.jts.geom.LineString;
+import org.locationtech.jts.geom.LineString;
 
 import fr.ign.cogit.cartagen.algorithms.block.deletion.BuildingDeletionOverlap;
 import fr.ign.cogit.cartagen.algorithms.block.displacement.BuildingDisplacementRandom;

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/geoxygene/CartAGenPlugin.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/geoxygene/CartAGenPlugin.java
@@ -29,7 +29,8 @@ import javax.swing.event.InternalFrameEvent;
 import javax.swing.table.TableModel;
 import javax.xml.bind.JAXBException;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.appli.geompool.GeometryPoolMenu;
 import fr.ign.cogit.cartagen.core.dataset.CartAGenDB;
@@ -66,7 +67,7 @@ public class CartAGenPlugin
   /**
    * Logger.
    */
-  static Logger logger = Logger.getLogger(CartAGenPlugin.class.getName());
+  static Logger logger = LogManager.getLogger(CartAGenPlugin.class.getName());
 
   protected static CartAGenPlugin instance = null;
 

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/geoxygene/ConfigMenuComponent.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/geoxygene/ConfigMenuComponent.java
@@ -16,8 +16,9 @@ import javax.swing.Action;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 
-import org.apache.log4j.Logger;
 import org.apache.log4j.PropertyConfigurator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Extra menu that contains utility functions of CartAGen.
@@ -27,7 +28,7 @@ import org.apache.log4j.PropertyConfigurator;
  */
 public class ConfigMenuComponent extends JMenu {
 
-    static Logger logger = Logger.getLogger(ConfigMenuComponent.class.getName());
+    static Logger logger = LogManager.getLogger(ConfigMenuComponent.class.getName());
 
     /**
      */

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/geoxygene/GeneralisationMenus.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/geoxygene/GeneralisationMenus.java
@@ -24,7 +24,8 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
@@ -47,7 +48,7 @@ import fr.ign.cogit.geoxygene.style.Layer;
  * @author julien Gaffuri 6 mars 2009
  */
 public class GeneralisationMenus {
-	static Logger logger = Logger.getLogger(GeneralisationMenus.class.getName());
+	static Logger logger = LogManager.getLogger(GeneralisationMenus.class.getName());
 
 	/**
 	 * @return

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/geoxygene/bookmarks/BookmarkSet.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/geoxygene/bookmarks/BookmarkSet.java
@@ -22,7 +22,8 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.xerces.dom.DocumentImpl;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -44,7 +45,7 @@ import fr.ign.cogit.geoxygene.util.XMLUtil;
  */
 public class BookmarkSet {
 
-  private static Logger logger = Logger.getLogger(BookmarkSet.class.getName());
+  private static Logger logger = LogManager.getLogger(BookmarkSet.class.getName());
   private HashSet<Bookmark> setBookmark;
   private CartAGenDB currentDataset;
   private ProjectFrame currentView;

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/geoxygene/dataset/CartAGenLoader.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/geoxygene/dataset/CartAGenLoader.java
@@ -3,7 +3,8 @@ package fr.ign.cogit.cartagen.appli.core.geoxygene.dataset;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.appli.utilities.ProgressFrame;
 import fr.ign.cogit.cartagen.core.dataset.CartAGenDataSet;
@@ -37,7 +38,7 @@ import fr.ign.cogit.geoxygene.util.index.Tiling;
 
 public class CartAGenLoader {
 
-	private static Logger logger = Logger.getLogger(CartAGenLoader.class.getName());
+	private static Logger logger = LogManager.getLogger(CartAGenLoader.class.getName());
 
 	public CartAGenLoader() {
 		super();

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/geoxygene/dataset/EnrichFrame.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/geoxygene/dataset/EnrichFrame.java
@@ -47,7 +47,7 @@ import fr.ign.cogit.geoxygene.style.UserStyle;
 public class EnrichFrame extends JDialog implements ActionListener {
 
     // private static Logger LOGGER =
-    // Logger.getLogger(EnrichFrame.class.getName());
+    // LogManager.getLogger(EnrichFrame.class.getName());
 
     private static final long serialVersionUID = -6992190369890036500L;
 

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/geoxygene/dataset/ExportFrame.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/geoxygene/dataset/ExportFrame.java
@@ -52,7 +52,7 @@ import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 
-import com.vividsolutions.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.GeometryFactory;
 
 import fr.ign.cogit.cartagen.appli.core.geoxygene.CartAGenPlugin;
 import fr.ign.cogit.cartagen.appli.core.geoxygene.selection.SelectionUtil;

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/geoxygene/dataset/ExportPostGISFrame.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/geoxygene/dataset/ExportPostGISFrame.java
@@ -56,7 +56,7 @@ import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 
-import com.vividsolutions.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.GeometryFactory;
 
 import fr.ign.cogit.cartagen.appli.core.geoxygene.CartAGenPlugin;
 import fr.ign.cogit.cartagen.appli.core.geoxygene.selection.SelectionUtil;

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/geoxygene/dataset/LoaderUtil.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/geoxygene/dataset/LoaderUtil.java
@@ -23,14 +23,15 @@ import java.util.Vector;
 import javax.swing.DefaultListModel;
 import javax.swing.JOptionPane;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.geotools.data.shapefile.files.ShpFiles;
 import org.geotools.data.shapefile.shp.ShapefileException;
 import org.geotools.data.shapefile.shp.ShapefileReader;
 import org.geotools.data.shapefile.shp.ShapefileReader.Record;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
 
 import fr.ign.cogit.cartagen.core.dataset.CartAGenDataSet;
 import fr.ign.cogit.cartagen.core.dataset.CartAGenDoc;
@@ -41,7 +42,7 @@ import fr.ign.cogit.geoxygene.util.conversion.AdapterFactory;
 
 public class LoaderUtil {
   @SuppressWarnings("unused")
-  private static Logger logger = Logger.getLogger(LoaderUtil.class.getName());
+  private static Logger logger = LogManager.getLogger(LoaderUtil.class.getName());
 
   // Supported file extensions
   public static final String ext[] = { "shp", "shx", "dbf" };

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/geoxygene/dataset/LoadingFrame.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/geoxygene/dataset/LoadingFrame.java
@@ -34,7 +34,8 @@ import javax.swing.ListSelectionModel;
 import javax.swing.SwingConstants;
 import javax.swing.WindowConstants;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.appli.utilities.renderer.LoadingListCellRenderer;
 
@@ -47,7 +48,7 @@ import fr.ign.cogit.cartagen.appli.utilities.renderer.LoadingListCellRenderer;
 
 public class LoadingFrame extends JFrame implements ActionListener {
     private static final long serialVersionUID = -6992190369890036500L;
-    private static Logger logger = Logger.getLogger(LoadingFrame.class.getName());
+    private static Logger logger = LogManager.getLogger(LoadingFrame.class.getName());
 
     // Utils
     public static String cheminAbsolu;

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/themes/TownMenu.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/core/themes/TownMenu.java
@@ -29,8 +29,8 @@ import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 
 import com.opencsv.CSVWriter;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.geom.Polygon;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
 
 import fr.ign.cogit.cartagen.appli.core.geoxygene.CartAGenPlugin;
 import fr.ign.cogit.cartagen.appli.core.geoxygene.selection.SelectionUtil;

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/geompool/GeometryPoolMenu.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/geompool/GeometryPoolMenu.java
@@ -36,7 +36,8 @@ import javax.swing.JTable;
 import javax.swing.SpinnerModel;
 import javax.swing.SpinnerNumberModel;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.appli.core.geoxygene.CartAGenPlugin;
 import fr.ign.cogit.cartagen.appli.utilities.ColorEditor;
@@ -75,7 +76,7 @@ import fr.ign.cogit.geoxygene.util.algo.geometricAlgorithms.morphomaths.Side;
  */
 public class GeometryPoolMenu extends JMenu {
 
-    static Logger logger = Logger.getLogger(GeometryPoolMenu.class.getName());
+    static Logger logger = LogManager.getLogger(GeometryPoolMenu.class.getName());
 
     private static GeometryPoolMenu instance;
 

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/plugins/machinelearning/TensorFlowPlugin.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/plugins/machinelearning/TensorFlowPlugin.java
@@ -30,9 +30,10 @@ import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JMenu;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-import com.vividsolutions.jts.geom.Geometry;
+import org.locationtech.jts.geom.Geometry;
 
 import fr.ign.cogit.cartagen.agents.core.AgentGeneralisationScheduler;
 import fr.ign.cogit.cartagen.agents.core.AgentUtil;
@@ -79,7 +80,7 @@ public class TensorFlowPlugin extends JMenu {
      */
     private static final long serialVersionUID = 1L;
     private static TensorFlowPlugin instance = null;
-    private static Logger logger = Logger.getLogger(TensorFlowPlugin.class.getName());
+    private static Logger logger = LogManager.getLogger(TensorFlowPlugin.class.getName());
 
     public TensorFlowPlugin() {
         // Exists only to defeat instantiation.

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/plugins/machinelearning/TrainingDatasetGenerator.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/plugins/machinelearning/TrainingDatasetGenerator.java
@@ -27,7 +27,8 @@ import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JMenu;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.deeplearning.vector2image.CoordinateTransformation;
 import fr.ign.cogit.cartagen.appli.core.geoxygene.CartAGenPlugin;
@@ -61,7 +62,7 @@ public class TrainingDatasetGenerator extends JMenu {
     private static int IMAGE_SIZE = 128;
     private static final long serialVersionUID = 1L;
     private static TrainingDatasetGenerator instance = null;
-    private static Logger logger = Logger
+    private static Logger logger = LogManager
             .getLogger(TrainingDatasetGenerator.class.getName());
 
     public TrainingDatasetGenerator() {

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/plugins/process/ContinuousGUIComponent.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/plugins/process/ContinuousGUIComponent.java
@@ -52,8 +52,8 @@ import org.geotools.data.shapefile.shp.ShapefileReader;
 import org.geotools.data.shapefile.shp.ShapefileReader.Record;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
 
 import fr.ign.cogit.cartagen.algorithms.polygon.VisvalingamWhyatt;
 import fr.ign.cogit.cartagen.appli.core.geoxygene.selection.LoadSelectionFrame;

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/plugins/process/collagen/CollaGenComponent.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/plugins/process/collagen/CollaGenComponent.java
@@ -14,7 +14,8 @@ import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 
@@ -78,7 +79,7 @@ public class CollaGenComponent extends JMenu {
 
 	private CollaGenEnvironment environment;
 	public static String ONTOLOGY = "OntoGeneralisation";
-	private static Logger LOGGER = Logger.getLogger(CollaGenComponent.class);
+	private static Logger LOGGER = LogManager.getLogger(CollaGenComponent.class);
 
 	public CollaGenComponent() {
 		// Exists only to defeat instantiation.

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/plugins/process/leastsquares/LeastSquaresComponent.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/plugins/process/leastsquares/LeastSquaresComponent.java
@@ -43,7 +43,7 @@ import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.GeometryFactory;
 
 import fr.ign.cogit.cartagen.appli.core.geoxygene.CartAGenPlugin;
 import fr.ign.cogit.cartagen.appli.core.geoxygene.selection.SelectionUtil;

--- a/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/utilities/GeneralisationLaunchingFrame.java
+++ b/cartagen-appli/src/main/java/fr/ign/cogit/cartagen/appli/utilities/GeneralisationLaunchingFrame.java
@@ -32,7 +32,8 @@ import javax.swing.JFrame;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * @author JGaffuri
@@ -40,7 +41,7 @@ import org.apache.log4j.Logger;
 public class GeneralisationLaunchingFrame extends JFrame {
   private static final long serialVersionUID = 1L;
 
-  private static final Logger logger = Logger
+  private static final Logger logger = LogManager
       .getLogger(GeneralisationLaunchingFrame.class.getName());
 
   /**

--- a/cartagen-core/pom.xml
+++ b/cartagen-core/pom.xml
@@ -9,17 +9,23 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <main.basedir>${project.parent.basedir}</main.basedir>
   </properties>
-  <artifactId>cartagen-core</artifactId>
-	<dependencies>  
-  		<dependency>
+	<artifactId>cartagen-core</artifactId>
+
+	<dependencies>
+		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>geoxygene-osm</artifactId>
-			<version>1.9-SNAPSHOT</version>
+			<version>${geoxygene.version}</version>
 		</dependency>
 		<dependency>
-  			<groupId>org.tensorflow</groupId>
-  			<artifactId>tensorflow</artifactId>
-  			<version>1.8.0</version>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>geoxygene-util</artifactId>
+			<version>${geoxygene.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.tensorflow</groupId>
+			<artifactId>tensorflow</artifactId>
+			<version>1.8.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.geotools</groupId>

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/CartAComInitialisations.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/CartAComInitialisations.java
@@ -14,7 +14,8 @@ import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -33,7 +34,7 @@ public class CartAComInitialisations {
   // //////////////////////////////////////////
 
   // All static fields //
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(CartAComInitialisations.class.getName());
 
   // Public fields //

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/CartAComLifeCycle.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/CartAComLifeCycle.java
@@ -2,7 +2,8 @@ package fr.ign.cogit.cartagen.agents.cartacom;
 
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.cartacom.action.CartacomAction;
 import fr.ign.cogit.cartagen.agents.cartacom.action.InternalGeneralisationAction;
@@ -14,7 +15,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.lifecycle.AgentLifeCycle;
 
 public class CartAComLifeCycle implements AgentLifeCycle {
 
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(CartAComLifeCycle.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/action/ConstrainedZoneDrivenDisplacement.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/action/ConstrainedZoneDrivenDisplacement.java
@@ -6,7 +6,8 @@ package fr.ign.cogit.cartagen.agents.cartacom.action;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.cartacom.agent.interfaces.ICartAComAgentGeneralisation;
 import fr.ign.cogit.cartagen.agents.cartacom.agent.interfaces.ISmallCompactAgent;
@@ -56,7 +57,7 @@ public class ConstrainedZoneDrivenDisplacement extends AggregableActionImpl {
   /**
    * Logger for this class
    */
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(ConstrainedZoneDrivenDisplacement.class.getName());
 
   // Public fields //

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/action/ConstrainedZonesDrivenDisplacement.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/action/ConstrainedZonesDrivenDisplacement.java
@@ -6,7 +6,8 @@ package fr.ign.cogit.cartagen.agents.cartacom.action;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.cartacom.agent.interfaces.ICartacomAgent;
 import fr.ign.cogit.cartagen.agents.cartacom.agent.interfaces.ISmallCompactAgent;
@@ -37,7 +38,7 @@ public class ConstrainedZonesDrivenDisplacement extends AggregatedActionImpl {
   /**
    * Logger for this class
    */
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(ConstrainedZonesDrivenDisplacement.class.getName());
 
   // Public fields //

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/action/RotationAction.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/action/RotationAction.java
@@ -1,6 +1,7 @@
 package fr.ign.cogit.cartagen.agents.cartacom.action;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.cartacom.agent.interfaces.ICartacomAgent;
 import fr.ign.cogit.cartagen.agents.cartacom.constraint.buildingroad.BuildingOrientation;
@@ -15,7 +16,7 @@ public class RotationAction extends CartacomActionImpl {
   /**
    * Logger for this class
    */
-  private static Logger LOGGER = Logger
+  private static Logger LOGGER = LogManager
       .getLogger(RotationAction.class.getName());
 
   public RotationAction(ICartacomAgent agent, GeographicConstraint constraint,

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/agent/CartacomAgent.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/agent/CartacomAgent.java
@@ -12,7 +12,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.cartacom.action.CartacomAction;
 import fr.ign.cogit.cartagen.agents.cartacom.agent.interfaces.ICartacomAgent;
@@ -69,7 +70,7 @@ public abstract class CartacomAgent extends GeographicAgent
   /**
    * Logger for this class
    */
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(TryActionTask.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/agent/FSMBasedConversationManager.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/agent/FSMBasedConversationManager.java
@@ -7,7 +7,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.cartacom.conversation.ConversationState;
 import fr.ign.cogit.cartagen.agents.cartacom.conversation.ConversationStateType;
@@ -44,7 +45,7 @@ public class FSMBasedConversationManager extends FSMBasedConversationalObject
   /**
    * Logger for this class
    */
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(FSMBasedConversationManager.class.getName());
 
   // Public fields //

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/agent/FSMBasedConversationalObject.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/agent/FSMBasedConversationalObject.java
@@ -9,7 +9,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.cartacom.conversation.ConversationRetrievalException;
 import fr.ign.cogit.cartagen.agents.cartacom.conversation.ConversationState;
@@ -59,7 +60,7 @@ public abstract class FSMBasedConversationalObject
   /**
    * Logger for this class
    */
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(FSMBasedConversationalObject.class.getName());
 
   // Public fields //

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/agent/impl/BuildingAgent.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/agent/impl/BuildingAgent.java
@@ -3,7 +3,8 @@
  */
 package fr.ign.cogit.cartagen.agents.cartacom.agent.impl;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.cartacom.agent.interfaces.IBuildingAgent;
 import fr.ign.cogit.cartagen.agents.core.AgentUtil;
@@ -16,7 +17,7 @@ import fr.ign.cogit.cartagen.core.genericschema.urban.IBuilding;
  */
 public class BuildingAgent extends SmallCompactAgent implements IBuildingAgent {
 
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(BuildingAgent.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/agent/impl/CartAComAgentGeneralisation.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/agent/impl/CartAComAgentGeneralisation.java
@@ -7,7 +7,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.cartacom.CartacomSpecifications;
 import fr.ign.cogit.cartagen.agents.cartacom.RelationalConstraintDescriptor;
@@ -59,7 +60,7 @@ public abstract class CartAComAgentGeneralisation extends CartacomAgent
   /**
    * Logger for this class
    */
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(ICartAComAgentGeneralisation.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/agent/impl/NetworkFaceAgent.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/agent/impl/NetworkFaceAgent.java
@@ -6,7 +6,8 @@ package fr.ign.cogit.cartagen.agents.cartacom.agent.impl;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.cartacom.agent.interfaces.INetworkSectionAgent;
 import fr.ign.cogit.cartagen.agents.cartacom.agent.interfaces.ISmallCompactAgent;
@@ -28,7 +29,7 @@ public class NetworkFaceAgent extends CartAComAgentGeneralisation {
    * Logger for this class
    */
   @SuppressWarnings("unused")
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(NetworkFaceAgent.class.getName());
 
   // Public fields //

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/agent/impl/SmallCompactAgent.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/agent/impl/SmallCompactAgent.java
@@ -5,7 +5,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.cartacom.CartacomSpecifications;
 import fr.ign.cogit.cartagen.agents.cartacom.action.ConstrainedZoneDrivenDisplacement;
@@ -43,7 +44,7 @@ public class SmallCompactAgent extends CartAComAgentGeneralisation
   /**
    * Logger for this class
    */
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(ISmallCompactAgent.class.getName());
 
   // Public fields //

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/constraint/building2/BuildingProximity.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/constraint/building2/BuildingProximity.java
@@ -7,7 +7,8 @@ import java.awt.Color;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.cartacom.CartacomSpecifications;
 import fr.ign.cogit.cartagen.agents.cartacom.action.CartacomAction;
@@ -32,7 +33,7 @@ import fr.ign.cogit.geoxygene.util.algo.geometricAlgorithms.morphomaths.Morpholo
  */
 public class BuildingProximity extends MicroMicroRelationalConstraintWithZone {
 
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(BuildingProximity.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/constraint/buildingnetface/BuildingTopology.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/constraint/buildingnetface/BuildingTopology.java
@@ -2,7 +2,8 @@ package fr.ign.cogit.cartagen.agents.cartacom.constraint.buildingnetface;
 
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.cartacom.CartacomSpecifications;
 import fr.ign.cogit.cartagen.agents.cartacom.agent.impl.NetworkFaceAgent;
@@ -19,7 +20,7 @@ public class BuildingTopology extends MicroMicroRelationalConstraintWithZone {
    * Logger for this class
    */
   @SuppressWarnings("unused")
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(BuildingTopology.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/constraint/buildingroad/BuildingOrientation.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/constraint/buildingroad/BuildingOrientation.java
@@ -6,7 +6,8 @@ package fr.ign.cogit.cartagen.agents.cartacom.constraint.buildingroad;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.cartacom.CartacomSpecifications;
 import fr.ign.cogit.cartagen.agents.cartacom.action.CartacomAction;
@@ -27,7 +28,7 @@ public class BuildingOrientation extends MicroMicroRelationalConstraint {
   /**
    * Logger for this class
    */
-  private static Logger LOGGER = Logger.getLogger(Parallelism.class.getName());
+  private static Logger LOGGER = LogManager.getLogger(Parallelism.class.getName());
 
   public BuildingOrientation(ICartAComAgentGeneralisation ag,
       MicroMicroRelation rel, double importance) {

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/conversation/ConversationTransition.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/conversation/ConversationTransition.java
@@ -1,6 +1,7 @@
 package fr.ign.cogit.cartagen.agents.cartacom.conversation;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.task.TaskResult;
 
@@ -23,7 +24,7 @@ public class ConversationTransition {
   /**
    * Logger for this class
    */
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(ConversationTransition.class.getName());
 
   // Public fields //

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/conversation/HalfConversationScenario.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/conversation/HalfConversationScenario.java
@@ -8,7 +8,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Describes a conversation scenario seen from the point of view of one of the
@@ -33,7 +34,7 @@ public class HalfConversationScenario {
   /**
    * Logger for this class
    */
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(HalfConversationScenario.class.getName());
   /**
    * All declared HalfConversationScenario.

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/relation/building2/Proximity.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/relation/building2/Proximity.java
@@ -5,7 +5,8 @@ package fr.ign.cogit.cartagen.agents.cartacom.relation.building2;
 
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.cartacom.CartacomSpecifications;
 import fr.ign.cogit.cartagen.agents.cartacom.agent.interfaces.ICartAComAgentGeneralisation;
@@ -36,7 +37,7 @@ public class Proximity extends MicroMicroRelation {
   /**
    * Logger for this class
    */
-  private static Logger logger = Logger.getLogger(Proximity.class.getName());
+  private static Logger logger = LogManager.getLogger(Proximity.class.getName());
 
   // //////////////////////////////////////
   // All constructors //

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/relation/buildingroad/Parallelism.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/cartacom/relation/buildingroad/Parallelism.java
@@ -2,7 +2,8 @@ package fr.ign.cogit.cartagen.agents.cartacom.relation.buildingroad;
 
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.cartacom.CartacomSpecifications;
 import fr.ign.cogit.cartagen.agents.cartacom.agent.impl.NetworkFaceAgent;
@@ -23,7 +24,7 @@ public class Parallelism extends MicroMicroRelation {
   /**
    * Logger for this class
    */
-  private static Logger LOGGER = Logger.getLogger(Parallelism.class.getName());
+  private static Logger LOGGER = LogManager.getLogger(Parallelism.class.getName());
 
   /**
    * @param ag1

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/AgentGeneralisationScheduler.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/AgentGeneralisationScheduler.java
@@ -6,7 +6,8 @@ import java.util.HashSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.core.Legend;
 import fr.ign.cogit.geoxygene.contrib.agents.AgentObservationSubject;
@@ -19,7 +20,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.agent.IAgent;
  */
 public class AgentGeneralisationScheduler extends Scheduler
     implements AgentObservationSubject, Callable<Integer> {
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(AgentGeneralisationScheduler.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/AgentSpecifications.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/AgentSpecifications.java
@@ -3,7 +3,8 @@
  */
 package fr.ign.cogit.cartagen.agents.core;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.geoxygene.contrib.agents.lifecycle.AgentLifeCycle;
 import fr.ign.cogit.geoxygene.contrib.agents.lifecycle.TreeExplorationLifeCycle;
@@ -15,7 +16,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.lifecycle.TreeExplorationLifeCycle;
  */
 public final class AgentSpecifications {
     @SuppressWarnings("unused")
-    private static Logger logger = Logger.getLogger(AgentSpecifications.class.getName());
+    private static Logger logger = LogManager.getLogger(AgentSpecifications.class.getName());
 
     public static boolean STORE_STATES = false;
 

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/AgentUtil.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/AgentUtil.java
@@ -9,7 +9,8 @@ import java.util.Set;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -88,7 +89,7 @@ import fr.ign.cogit.geoxygene.util.conversion.AdapterFactory;
  */
 
 public class AgentUtil {
-  protected final static Logger logger = Logger
+  protected final static Logger logger = LogManager
       .getLogger(AgentUtil.class.getName());
 
   public static Logger getLogger() {

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/action/InternStructuresActivation.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/action/InternStructuresActivation.java
@@ -2,7 +2,8 @@ package fr.ign.cogit.cartagen.agents.core.action;
 
 import java.util.ArrayList;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.geoxygene.contrib.agents.action.ActionResult;
 import fr.ign.cogit.geoxygene.contrib.agents.agent.GeographicObjectAgent;
@@ -19,7 +20,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.constraint.Constraint;
  */
 public class InternStructuresActivation<ComponentClass extends GeographicObjectAgent>
     extends ActionCartagen {
-  final static Logger logger = Logger
+  final static Logger logger = LogManager
       .getLogger(InternStructuresActivation.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/action/MesoComponentsActivation.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/action/MesoComponentsActivation.java
@@ -2,7 +2,8 @@ package fr.ign.cogit.cartagen.agents.core.action;
 
 import java.util.ArrayList;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.geoxygene.contrib.agents.action.ActionResult;
 import fr.ign.cogit.geoxygene.contrib.agents.agent.GeographicObjectAgent;
@@ -19,7 +20,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.constraint.Constraint;
  */
 public class MesoComponentsActivation<ComponentClass extends GeographicObjectAgent>
     extends ActionCartagen {
-  final static Logger logger = Logger
+  final static Logger logger = LogManager
       .getLogger(MesoComponentsActivation.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/action/StructureActivationAction.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/action/StructureActivationAction.java
@@ -3,7 +3,8 @@ package fr.ign.cogit.cartagen.agents.core.action;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.geoxygene.contrib.agents.action.ActionResult;
 import fr.ign.cogit.geoxygene.contrib.agents.agent.GeographicObjectAgent;
@@ -16,7 +17,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.constraint.Constraint;
  * 
  */
 public class StructureActivationAction extends ActionCartagen {
-  final static Logger logger = Logger
+  final static Logger logger = LogManager
       .getLogger(StructureActivationAction.class.getName());
 
   public StructureActivationAction(GeographicObjectAgent ag, Constraint cont,

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/action/StructureComponentsActivation.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/action/StructureComponentsActivation.java
@@ -2,7 +2,8 @@ package fr.ign.cogit.cartagen.agents.core.action;
 
 import java.util.ArrayList;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.geoxygene.contrib.agents.action.ActionResult;
 import fr.ign.cogit.geoxygene.contrib.agents.agent.GeographicObjectAgent;
@@ -17,7 +18,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.constraint.Constraint;
  * 
  */
 public class StructureComponentsActivation extends ActionCartagen {
-  final static Logger logger = Logger
+  final static Logger logger = LogManager
       .getLogger(StructureComponentsActivation.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/action/block/BlockBuildingsDeletionCongestionAction.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/action/block/BlockBuildingsDeletionCongestionAction.java
@@ -3,7 +3,8 @@ package fr.ign.cogit.cartagen.agents.core.action.block;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.AgentUtil;
 import fr.ign.cogit.cartagen.agents.core.action.ActionCartagen;
@@ -23,7 +24,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.constraint.Constraint;
  */
 public class BlockBuildingsDeletionCongestionAction extends ActionCartagen {
 
-  static Logger logger = Logger.getLogger(SimplificationAction.class.getName());
+  static Logger logger = LogManager.getLogger(SimplificationAction.class.getName());
   /**
    */
   private int nbLimite;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/action/micro/EnlargementAction.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/action/micro/EnlargementAction.java
@@ -1,6 +1,7 @@
 package fr.ign.cogit.cartagen.agents.core.action.micro;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.action.ActionCartagen;
 import fr.ign.cogit.cartagen.agents.core.agent.IMicroAgentGeneralisation;
@@ -15,7 +16,7 @@ import fr.ign.cogit.geoxygene.util.algo.CommonAlgorithms;
  * 
  */
 public class EnlargementAction extends ActionCartagen {
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(EnlargementAction.class.getName());
   /**
    */

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/action/micro/SimplificationAction.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/action/micro/SimplificationAction.java
@@ -3,7 +3,8 @@
  */
 package fr.ign.cogit.cartagen.agents.core.action.micro;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.action.ActionCartagen;
 import fr.ign.cogit.cartagen.agents.core.agent.IMicroAgentGeneralisation;
@@ -18,7 +19,7 @@ import fr.ign.cogit.geoxygene.generalisation.simplification.SimplificationAlgori
  * 
  */
 public class SimplificationAction extends ActionCartagen {
-  static Logger logger = Logger.getLogger(SimplificationAction.class.getName());
+  static Logger logger = LogManager.getLogger(SimplificationAction.class.getName());
   /**
    */
   @ActionField

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/action/micro/SmallestSurroundingRectangleAction.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/action/micro/SmallestSurroundingRectangleAction.java
@@ -1,6 +1,7 @@
 package fr.ign.cogit.cartagen.agents.core.action.micro;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.action.ActionCartagen;
 import fr.ign.cogit.cartagen.agents.core.agent.IMicroAgentGeneralisation;
@@ -15,7 +16,7 @@ import fr.ign.cogit.geoxygene.util.algo.SmallestSurroundingRectangleComputation;
  * 
  */
 public class SmallestSurroundingRectangleAction extends ActionCartagen {
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(SmallestSurroundingRectangleAction.class.getName());
   /**
    */

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/action/network/SmallDeadEndsDeletionAction.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/action/network/SmallDeadEndsDeletionAction.java
@@ -13,7 +13,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.constraint.Constraint;
  */
 public class SmallDeadEndsDeletionAction extends ActionCartagen {
   // private static Logger logger =
-  // Logger.getLogger(SuppressionPetitesImpasses.class.getName());
+  // LogManager.getLogger(SuppressionPetitesImpasses.class.getName());
   /**
    */
   private final double longueurMin;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/action/network/StreetSelectionRuas.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/action/network/StreetSelectionRuas.java
@@ -1,6 +1,7 @@
 package fr.ign.cogit.cartagen.agents.core.action.network;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.action.ActionCartagen;
 import fr.ign.cogit.cartagen.agents.core.agent.ITownAgent;
@@ -20,7 +21,7 @@ public class StreetSelectionRuas extends ActionCartagen {
   // //////////////////////////////////////////
 
   // All static fields //
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(StreetSelectionRuas.class.getSimpleName());
   // Public fields //
 

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/action/section/LineCoalescencePartitionAction.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/action/section/LineCoalescencePartitionAction.java
@@ -2,7 +2,8 @@ package fr.ign.cogit.cartagen.agents.core.action.section;
 
 import java.util.ArrayList;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.action.MesoComponentsActivation;
 import fr.ign.cogit.cartagen.agents.core.agent.network.MesoSectionAgent;
@@ -17,7 +18,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.constraint.Constraint;
  */
 public class LineCoalescencePartitionAction
     extends MesoComponentsActivation<SectionAgent> {
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(LineCoalescencePartitionAction.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/GeographicAgentGeneralisation.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/GeographicAgentGeneralisation.java
@@ -3,7 +3,8 @@ package fr.ign.cogit.cartagen.agents.core.agent;
 import java.util.ArrayList;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.gael.deformation.GAELDeformable;
 import fr.ign.cogit.cartagen.agents.gael.deformation.GAELDeformableImpl;
@@ -30,7 +31,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.state.AgentState;
 public abstract class GeographicAgentGeneralisation extends GeographicAgent
     implements GAELDeformable {
 
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(GeographicAgentGeneralisation.class.getName());
 
   // GAEL

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/GeographicObjectAgentGeneralisation.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/GeographicObjectAgentGeneralisation.java
@@ -6,7 +6,9 @@ package fr.ign.cogit.cartagen.agents.core.agent;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import fr.ign.cogit.cartagen.agents.gael.deformation.submicro.GAELTriangle;
 import fr.ign.cogit.cartagen.agents.gael.field.agent.FieldAgent;
@@ -32,7 +34,7 @@ public abstract class GeographicObjectAgentGeneralisation
     extends GeographicAgentGeneralisation
     implements GeographicObjectAgent, IGeographicObjectAgentGeneralisation {
 
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(GeographicObjectAgentGeneralisation.class.getName());
 
   private IGeneObj geneObj = null;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/InternStructureAgentGeneralisation.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/InternStructureAgentGeneralisation.java
@@ -6,7 +6,8 @@ package fr.ign.cogit.cartagen.agents.core.agent;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.constraint.MesoComponentsSatisfaction;
 import fr.ign.cogit.cartagen.agents.core.constraint.StructureComponentsSatisfaction;
@@ -25,7 +26,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.state.InternStructureAgentState;
 public abstract class InternStructureAgentGeneralisation extends
     GeographicObjectAgentGeneralisation implements InternStructureAgent {
 
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(InternStructureAgentGeneralisation.class.getName());
 
   public void ajouterContrainteSatisfactionComposantsStructure(

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/InternStructureAgentImpl.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/InternStructureAgentImpl.java
@@ -6,7 +6,8 @@ package fr.ign.cogit.cartagen.agents.core.agent;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.state.InternStructureAgentStateImpl;
 import fr.ign.cogit.geoxygene.contrib.agents.action.Action;
@@ -24,7 +25,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.state.InternStructureAgentState;
 public class InternStructureAgentImpl extends GeographicObjectAgentImpl
     implements InternStructureAgent {
 
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(InternStructureAgentImpl.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/MesoAgentGeneralisation.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/MesoAgentGeneralisation.java
@@ -4,7 +4,8 @@ import java.awt.Color;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.constraint.InternStructuresSatisfaction;
 import fr.ign.cogit.cartagen.agents.core.constraint.MesoComponentsSatisfaction;
@@ -24,7 +25,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.state.MesoAgentStateImpl;
 public abstract class MesoAgentGeneralisation<ComponentClass extends GeographicObjectAgent>
     extends GeographicObjectAgentGeneralisation
     implements MesoAgent<ComponentClass> {
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(MesoAgentGeneralisation.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/MesoAgentImpl.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/MesoAgentImpl.java
@@ -6,7 +6,8 @@ package fr.ign.cogit.cartagen.agents.core.agent;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.geoxygene.contrib.agents.action.Action;
 import fr.ign.cogit.geoxygene.contrib.agents.agent.GeographicObjectAgent;
@@ -24,7 +25,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.state.MesoAgentStateImpl;
  */
 public class MesoAgentImpl<ComponentClass extends GeographicObjectAgent>
     extends GeographicObjectAgentImpl implements MesoAgent<ComponentClass> {
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(MesoAgentImpl.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/network/MesoSectionAgent.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/network/MesoSectionAgent.java
@@ -5,7 +5,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.agent.ISectionAgent;
 import fr.ign.cogit.cartagen.agents.core.agent.MesoAgentGeneralisation;
@@ -34,7 +35,7 @@ import fr.ign.cogit.geoxygene.util.algo.CommonAlgorithms;
  * 
  */
 public class MesoSectionAgent extends MesoAgentGeneralisation<SectionAgent> {
-  private static Logger logger = Logger.getLogger(BlockAgent.class.getName());
+  private static Logger logger = LogManager.getLogger(BlockAgent.class.getName());
 
   /**
    * Constructor for meso section agent

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/network/NetworkNodeAgent.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/network/NetworkNodeAgent.java
@@ -5,7 +5,8 @@ package fr.ign.cogit.cartagen.agents.core.agent.network;
 
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.agent.ISectionAgent;
 import fr.ign.cogit.cartagen.agents.core.agent.MicroAgentGeneralisation;
@@ -18,7 +19,7 @@ import fr.ign.cogit.geoxygene.api.spatial.geomroot.IGeometry;
  */
 public class NetworkNodeAgent extends MicroAgentGeneralisation {
   @SuppressWarnings("unused")
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(NetworkNodeAgent.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/network/SectionAgent.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/network/SectionAgent.java
@@ -5,7 +5,8 @@ package fr.ign.cogit.cartagen.agents.core.agent.network;
 
 import java.util.ArrayList;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.AgentUtil;
 import fr.ign.cogit.cartagen.agents.core.agent.ISectionAgent;
@@ -32,7 +33,7 @@ import fr.ign.cogit.geoxygene.api.spatial.geomroot.IGeometry;
 public abstract class SectionAgent extends MicroAgentGeneralisation
     implements ISectionAgent {
   @SuppressWarnings("unused")
-  private static Logger logger = Logger.getLogger(SectionAgent.class.getName());
+  private static Logger logger = LogManager.getLogger(SectionAgent.class.getName());
 
   @Override
   public INetworkSection getFeature() {

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/network/electricity/ElectricitySectionAgent.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/network/electricity/ElectricitySectionAgent.java
@@ -11,7 +11,7 @@ import fr.ign.cogit.geoxygene.api.spatial.coordgeom.ILineString;
  */
 public class ElectricitySectionAgent extends SectionAgent {
   // private static Logger
-  // logger=Logger.getLogger(TronconElectricite.class.getName());
+  // logger=LogManager.getLogger(TronconElectricite.class.getName());
 
   @Override
   public IElectricityLine getFeature() {

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/network/hydro/HydroSectionAgent.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/network/hydro/HydroSectionAgent.java
@@ -32,7 +32,7 @@ import fr.ign.cogit.geoxygene.api.spatial.coordgeom.ILineString;
 public class HydroSectionAgent extends SectionAgent
     implements IHydroSectionAgent {
   // private static Logger
-  // logger=Logger.getLogger(TronconCoursEau.class.getName());
+  // logger=LogManager.getLogger(TronconCoursEau.class.getName());
 
   @Override
   public IWaterLine getFeature() {

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/network/hydro/HydroSurfaceAgent.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/network/hydro/HydroSurfaceAgent.java
@@ -12,7 +12,7 @@ import fr.ign.cogit.geoxygene.spatial.coordgeom.GM_Polygon;
  * 
  */
 public class HydroSurfaceAgent extends SmallCompactAgent {
-  // private static Logger logger=Logger.getLogger(SurfaceEau.class.getName());
+  // private static Logger logger=LogManager.getLogger(SurfaceEau.class.getName());
 
   @Override
   public IWaterArea getFeature() {

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/network/rail/RailroadSectionAgent.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/network/rail/RailroadSectionAgent.java
@@ -11,7 +11,7 @@ import fr.ign.cogit.geoxygene.api.spatial.coordgeom.ILineString;
  */
 public class RailroadSectionAgent extends SectionAgent {
   // private static Logger
-  // logger=Logger.getLogger(TronconVoieFerree.class.getName());
+  // logger=LogManager.getLogger(TronconVoieFerree.class.getName());
 
   @Override
   public IRailwayLine getFeature() {

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/network/road/RoadNetworkAgent.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/network/road/RoadNetworkAgent.java
@@ -12,7 +12,7 @@ import fr.ign.cogit.cartagen.core.genericschema.network.INetwork;
  */
 public final class RoadNetworkAgent extends NetworkAgent {
   // private static Logger
-  // logger=Logger.getLogger(ReseauRoutier.class.getName());
+  // logger=LogManager.getLogger(ReseauRoutier.class.getName());
 
   public RoadNetworkAgent(INetwork net) {
     super(net);

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/network/road/RoadSectionAgent.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/network/road/RoadSectionAgent.java
@@ -18,7 +18,7 @@ import fr.ign.cogit.geoxygene.api.spatial.coordgeom.ILineString;
 public class RoadSectionAgent extends SectionAgent
     implements IRoadSectionAgent {
   // private static Logger
-  // logger=Logger.getLogger(TronconRoute.class.getName());
+  // logger=LogManager.getLogger(TronconRoute.class.getName());
 
   @Override
   public IRoadLine getFeature() {

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/urban/BlockAgent.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/urban/BlockAgent.java
@@ -7,7 +7,8 @@ import java.awt.Color;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.AgentSpecifications;
 import fr.ign.cogit.cartagen.agents.core.AgentUtil;
@@ -39,7 +40,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.agent.GeographicObjectAgent;
  */
 public class BlockAgent extends MesoAgentGeneralisation<IUrbanElementAgent>
     implements IBlockAgent {
-  private static Logger logger = Logger.getLogger(BlockAgent.class.getName());
+  private static Logger logger = LogManager.getLogger(BlockAgent.class.getName());
 
   @Override
   public IPolygon getGeom() {

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/urban/BuildingAgent.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/urban/BuildingAgent.java
@@ -1,6 +1,7 @@
 package fr.ign.cogit.cartagen.agents.core.agent.urban;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.AgentSpecifications;
 import fr.ign.cogit.cartagen.agents.core.AgentUtil;
@@ -29,7 +30,7 @@ import fr.ign.cogit.geoxygene.generalisation.simplification.PolygonSegment;
  * 
  */
 public class BuildingAgent extends UrbanElementAgent implements IBuildingAgent {
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(BuildingAgent.class.getName());
 
   @Override

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/urban/TownAgent.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/agent/urban/TownAgent.java
@@ -5,7 +5,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.AgentSpecifications;
 import fr.ign.cogit.cartagen.agents.core.AgentUtil;
@@ -31,7 +32,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.agent.GeographicObjectAgent;
 public class TownAgent extends MesoAgentGeneralisation<IBlockAgent>
     implements ITownAgent {
   @SuppressWarnings("unused")
-  private static Logger logger = Logger.getLogger(TownAgent.class.getName());
+  private static Logger logger = LogManager.getLogger(TownAgent.class.getName());
 
   @Override
   public IPolygon getGeom() {

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/constraint/building/Squareness.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/constraint/building/Squareness.java
@@ -3,7 +3,8 @@ package fr.ign.cogit.cartagen.agents.core.constraint.building;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.action.micro.LSSquarringAction;
 import fr.ign.cogit.cartagen.agents.core.action.micro.SimpleSquaringAction;
@@ -26,7 +27,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.constraint.GeographicObjectConstrai
  * @author AMaudet 07/02/2012
  */
 public class Squareness extends GeographicObjectConstraintImpl {
-  private static Logger logger = Logger.getLogger(Squareness.class.getName());
+  private static Logger logger = LogManager.getLogger(Squareness.class.getName());
 
   /**
    * Number of almost right angle in the figure. An almost right angle is an

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/constraint/network/Squareness.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/constraint/network/Squareness.java
@@ -3,7 +3,8 @@ package fr.ign.cogit.cartagen.agents.core.constraint.network;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.action.micro.LSSquarringAction;
 import fr.ign.cogit.cartagen.agents.core.action.micro.SimpleSquaringAction;
@@ -26,7 +27,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.constraint.GeographicObjectConstrai
  * @author AMaudet 07/02/2012
  */
 public class Squareness extends GeographicObjectConstraintImpl {
-  private static Logger logger = Logger.getLogger(Squareness.class.getName());
+  private static Logger logger = LogManager.getLogger(Squareness.class.getName());
 
   /**
    * Number of almost right angle in the figure. An almost right angle is an

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/constraint/section/Coalescence.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/constraint/section/Coalescence.java
@@ -4,7 +4,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.action.section.CurvatureSmoothingAction;
 import fr.ign.cogit.cartagen.agents.core.action.section.LineCoalescencePartitionAction;
@@ -24,7 +25,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.constraint.GeographicObjectConstrai
 public class Coalescence extends GeographicObjectConstraintImpl {
 
   @SuppressWarnings("unused")
-  private static Logger logger = Logger.getLogger(Coalescence.class.getName());
+  private static Logger logger = LogManager.getLogger(Coalescence.class.getName());
 
   /**
    */

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/constraint/section/DeformationControl.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/constraint/section/DeformationControl.java
@@ -2,7 +2,8 @@ package fr.ign.cogit.cartagen.agents.core.constraint.section;
 
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.agent.GeographicObjectAgentGeneralisation;
 import fr.ign.cogit.cartagen.agents.core.agent.ISectionAgent;
@@ -16,7 +17,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.constraint.GeographicObjectConstrai
 public class DeformationControl extends GeographicObjectConstraintImpl {
 
   @SuppressWarnings("unused")
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(DeformationControl.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/constraint/section/road/NonOverlapping.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/constraint/section/road/NonOverlapping.java
@@ -2,7 +2,8 @@ package fr.ign.cogit.cartagen.agents.core.constraint.section.road;
 
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.agent.GeographicObjectAgentGeneralisation;
 import fr.ign.cogit.cartagen.agents.core.agent.IRoadSectionAgent;
@@ -16,7 +17,7 @@ import fr.ign.cogit.geoxygene.spatial.coordgeom.GM_Polygon;
 public class NonOverlapping extends GeographicObjectConstraintImpl {
 
   @SuppressWarnings("unused")
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(NonOverlapping.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/task/AcknowledgeInformationTask.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/task/AcknowledgeInformationTask.java
@@ -5,7 +5,8 @@ package fr.ign.cogit.cartagen.agents.core.task;
 
 import java.util.Iterator;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.cartacom.agent.CartacomAgent;
 import fr.ign.cogit.cartagen.agents.cartacom.agent.ConversationalObject;
@@ -33,7 +34,7 @@ public class AcknowledgeInformationTask extends EndOfConvTaskImpl {
   /**
    * Logger for this class
    */
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(AcknowledgeInformationTask.class.getName());
 
   // Public fields //

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/task/AcknowledgeRequestForActionResultTask.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/task/AcknowledgeRequestForActionResultTask.java
@@ -3,7 +3,8 @@
  */
 package fr.ign.cogit.cartagen.agents.core.task;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.cartacom.agent.ConversationalObject;
 import fr.ign.cogit.cartagen.agents.cartacom.agent.interfaces.ICartacomAgent;
@@ -31,7 +32,7 @@ public class AcknowledgeRequestForActionResultTask extends EndOfConvTaskImpl {
   /**
    * Logger for this class
    */
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(AcknowledgeRequestForActionResultTask.class.getName());
 
   // Public fields //

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/task/EndOfConvTaskImpl.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/task/EndOfConvTaskImpl.java
@@ -3,7 +3,8 @@
  */
 package fr.ign.cogit.cartagen.agents.core.task;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Default implementation of interface EndOfConvTask, based on
@@ -26,7 +27,7 @@ public abstract class EndOfConvTaskImpl extends TaskWithinConversationImpl
   /**
    * Logger for this class
    */
-  private static Logger logger = Logger.getLogger(EndOfConvTaskImpl.class
+  private static Logger logger = LogManager.getLogger(EndOfConvTaskImpl.class
       .getName());
 
   // Public fields //

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/task/LetToDoActionTask.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/task/LetToDoActionTask.java
@@ -1,6 +1,7 @@
 package fr.ign.cogit.cartagen.agents.core.task;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.cartacom.action.CartacomAction;
 import fr.ign.cogit.cartagen.agents.cartacom.agent.interfaces.ICartacomAgent;
@@ -13,7 +14,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.relation.RelationalConstraint;
 
 public class LetToDoActionTask extends ProcessingTaskWithinConvImpl {
 
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(LetToDoActionTask.class.getName());
 
   private CartacomAction action;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/task/ProcessingTaskWithinConvImpl.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/task/ProcessingTaskWithinConvImpl.java
@@ -3,7 +3,8 @@
  */
 package fr.ign.cogit.cartagen.agents.core.task;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.cartacom.agent.ConversationalObject;
 import fr.ign.cogit.cartagen.agents.cartacom.conversation.ConversationState;
@@ -29,7 +30,7 @@ public abstract class ProcessingTaskWithinConvImpl
   /**
    * Logger for this class
    */
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(ProcessingTaskWithinConv.class.getName());
 
   // Public fields //

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/task/TryActionTask.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/core/task/TryActionTask.java
@@ -9,7 +9,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.cartacom.action.CartacomAction;
 import fr.ign.cogit.cartagen.agents.cartacom.action.InternalGeneralisationAction;
@@ -45,7 +46,7 @@ public class TryActionTask extends ProcessingTaskWithinConvImpl {
   /**
    * Logger for this class
    */
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(TryActionTask.class.getName());
 
   /*

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/agent/model/DiogenAgent.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/agent/model/DiogenAgent.java
@@ -3,7 +3,8 @@ package fr.ign.cogit.cartagen.agents.diogen.agent.model;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.diogen.lifecycle.PadawanAgentLifeCycle;
 import fr.ign.cogit.cartagen.agents.diogen.padawan.BorderStrategy;
@@ -15,7 +16,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.agent.AgentSatisfactionState;
 
 public abstract class DiogenAgent implements IDiogenAgent {
 
-  private static Logger logger = Logger.getLogger(DiogenAgent.class.getName());
+  private static Logger logger = LogManager.getLogger(DiogenAgent.class.getName());
 
   public DiogenAgent() {
     super();

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/algorithms/AdjacentBuildingsDecomposition.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/algorithms/AdjacentBuildingsDecomposition.java
@@ -9,7 +9,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.diogen.PadawanUtil;
 import fr.ign.cogit.cartagen.agents.diogen.agent.model.GeographicPointAgent;
@@ -52,7 +53,7 @@ import fr.ign.cogit.geoxygene.util.algo.JtsAlgorithms;
 
 public class AdjacentBuildingsDecomposition {
 
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(AdjacentBuildingsDecomposition.class.getName());
 
   // a population for the building aggregation

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/algorithms/Algorithms.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/algorithms/Algorithms.java
@@ -3,7 +3,8 @@ package fr.ign.cogit.cartagen.agents.diogen.algorithms;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.core.genericschema.IGeneObj;
 import fr.ign.cogit.cartagen.core.genericschema.IGeneObjLin;
@@ -17,7 +18,7 @@ import fr.ign.cogit.geoxygene.util.algo.geomstructure.Vector2D;
 
 public class Algorithms {
 
-  private static Logger logger = Logger.getLogger(Algorithms.class.getName());
+  private static Logger logger = LogManager.getLogger(Algorithms.class.getName());
 
   public static Set<ICurveSegment> getParallelLines(Vector2D vector,
       Set<INetworkSection> linesSet) {

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/algorithms/RayTracingFromLinear.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/algorithms/RayTracingFromLinear.java
@@ -4,7 +4,7 @@ import java.util.Hashtable;
 import java.util.Map;
 import java.util.Set;
 
-import com.vividsolutions.jts.geom.LineString;
+import org.locationtech.jts.geom.LineString;
 
 import fr.ign.cogit.cartagen.core.defaultschema.misc.MiscLine;
 import fr.ign.cogit.cartagen.core.genericschema.IGeneObjLin;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/algorithms/SimplificationAlgorithmWithPointPosition.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/algorithms/SimplificationAlgorithmWithPointPosition.java
@@ -4,7 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.diogen.PadawanUtil;
 import fr.ign.cogit.cartagen.agents.diogen.agent.model.GeographicPointAgent;
@@ -26,7 +27,7 @@ import fr.ign.cogit.geoxygene.generalisation.simplification.SimplificationAlgori
 public class SimplificationAlgorithmWithPointPosition
     extends SimplificationAlgorithm {
 
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(SimplificationAlgorithmWithPointPosition.class.getName());
 
   private static double SEUIL_COTES_PARRALLELES = 20 * Math.PI / 180;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/hikingroutes/csproutes/Backtracking.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/hikingroutes/csproutes/Backtracking.java
@@ -4,7 +4,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.spatialanalysis.network.StrokeNode;
 
@@ -15,7 +16,7 @@ import fr.ign.cogit.cartagen.spatialanalysis.network.StrokeNode;
  */
 public class Backtracking {
 
-  private static Logger LOGGER = Logger.getLogger(Backtracking.class.getName());
+  private static Logger LOGGER = LogManager.getLogger(Backtracking.class.getName());
 
   /**
    * This function uses a dichotomic approach to solve the CSP problem

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/hikingroutes/csproutes/CSPSolver.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/hikingroutes/csproutes/CSPSolver.java
@@ -9,7 +9,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.google.common.collect.Iterables;
 
@@ -26,7 +27,7 @@ import utils.Pair;
  */
 public class CSPSolver {
 
-  private static Logger LOGGER = Logger.getLogger(CSPSolver.class.getName());
+  private static Logger LOGGER = LogManager.getLogger(CSPSolver.class.getName());
 
   /**
    * This function solves a CSP problem with 4 possible algorithms

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/hikingroutes/csproutes/ProblemConstraints.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/hikingroutes/csproutes/ProblemConstraints.java
@@ -7,7 +7,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.google.common.collect.Iterables;
 
@@ -22,7 +23,7 @@ import fr.ign.cogit.cartagen.spatialanalysis.network.StrokeNode;
  */
 public class ProblemConstraints {
 
-  private static Logger LOGGER = Logger
+  private static Logger LOGGER = LogManager
       .getLogger(ProblemConstraints.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/hikingroutes/csproutes/RoadStrokeForRoutes.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/hikingroutes/csproutes/RoadStrokeForRoutes.java
@@ -11,7 +11,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.persistence.Entity;
 import javax.persistence.Transient;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.diogen.hikingroutes.schema.ICarryingRoadLine;
 import fr.ign.cogit.cartagen.agents.diogen.hikingroutes.schema.IHikingRouteSection;
@@ -35,7 +36,7 @@ import fr.ign.cogit.geoxygene.schemageo.api.support.reseau.NoeudReseau;
 @Entity
 public class RoadStrokeForRoutes extends Stroke {
 
-  private static Logger LOGGER = Logger
+  private static Logger LOGGER = LogManager
       .getLogger(RoadStrokeForRoutes.class.getName());
 
   private static AtomicInteger COUNTER = new AtomicInteger();

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/hikingroutes/csproutes/RouteStrokesNetwork.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/hikingroutes/csproutes/RouteStrokesNetwork.java
@@ -8,7 +8,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.google.common.collect.Iterables;
 
@@ -30,7 +31,7 @@ import fr.ign.cogit.geoxygene.schemageo.api.support.reseau.NoeudReseau;
  */
 public class RouteStrokesNetwork extends RoadStrokesNetwork {
 
-  private static Logger LOGGER = Logger.getLogger(RouteStrokesNetwork.class
+  private static Logger LOGGER = LogManager.getLogger(RouteStrokesNetwork.class
       .getName());
 
   private Collection<StrokeNode> routeStrokeNodes;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/hikingroutes/csproutes/SimulatedAnnealing.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/hikingroutes/csproutes/SimulatedAnnealing.java
@@ -5,7 +5,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import utils.Pair;
 
@@ -20,7 +21,7 @@ import fr.ign.cogit.cartagen.spatialanalysis.network.StrokeNode;
  * 
  */
 public class SimulatedAnnealing {
-  private static Logger LOGGER = Logger.getLogger(SimulatedAnnealing.class
+  private static Logger LOGGER = LogManager.getLogger(SimulatedAnnealing.class
       .getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/hikingroutes/csproutes/TronconDeRouteItineraireImpl.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/hikingroutes/csproutes/TronconDeRouteItineraireImpl.java
@@ -3,7 +3,8 @@ package fr.ign.cogit.cartagen.agents.diogen.hikingroutes.csproutes;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.diogen.hikingroutes.schema.ICarryingRoadLine;
 import fr.ign.cogit.cartagen.agents.diogen.hikingroutes.schema.IHikingRouteSection;
@@ -22,7 +23,7 @@ import fr.ign.cogit.geoxygene.schemageo.impl.routier.TronconDeRouteImpl;
 public class TronconDeRouteItineraireImpl extends TronconDeRouteImpl
         implements TronconDeRouteItineraire {
 
-    protected static final Logger LOGGER = Logger
+    protected static final Logger LOGGER = LogManager
             .getLogger(TronconDeRouteItineraireImpl.class.getName());
 
     public TronconDeRouteItineraireImpl(Reseau res, boolean estFictif,

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/hikingroutes/csproutes/constraintsStaticFunctionsForCSP.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/hikingroutes/csproutes/constraintsStaticFunctionsForCSP.java
@@ -10,7 +10,7 @@ package fr.ign.cogit.cartagen.agents.diogen.hikingroutes.csproutes;
 public class constraintsStaticFunctionsForCSP {
   //
   // private static Logger LOGGER =
-  // Logger.getLogger(constraintsStaticFunctionsForCSP.class.getName());
+  // LogManager.getLogger(constraintsStaticFunctionsForCSP.class.getName());
   //
   // /**
   // * this function returns a node score according the number of crossed roads

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/hikingroutes/schema/Route.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/hikingroutes/schema/Route.java
@@ -4,7 +4,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.diogen.preprocessing.ComputeRouteSectionGeom;
 import fr.ign.cogit.cartagen.agents.diogen.preprocessing.ConcatLineStrings;
@@ -16,7 +17,7 @@ import fr.ign.cogit.geoxygene.spatial.geomaggr.GM_MultiSurface;
 public abstract class Route implements IRoute {
 
   @SuppressWarnings("unused")
-  private static final Logger LOGGER = Logger.getLogger(Route.class.getName());
+  private static final Logger LOGGER = LogManager.getLogger(Route.class.getName());
 
   private List<IRouteSection> routeSections = new ArrayList<IRouteSection>();
 

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/interaction/InteractionConfiguration.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/interaction/InteractionConfiguration.java
@@ -17,7 +17,8 @@ import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -34,7 +35,7 @@ import fr.ign.cogit.cartagen.agents.diogen.interactionmodel.constrained.Constrai
  */
 public class InteractionConfiguration {
 
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(InteractionConfiguration.class.getName());
 
   private static Map<String, Interaction> interactionsMap = null;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/interaction/meso/EmbeddedEnvironmentActivationInteraction.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/interaction/meso/EmbeddedEnvironmentActivationInteraction.java
@@ -5,7 +5,8 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.diogen.agent.model.EmbeddedEnvironmentAgent;
 import fr.ign.cogit.cartagen.agents.diogen.agent.model.IDiogenAgent;
@@ -21,7 +22,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.constraint.GeographicConstraint;
 public class EmbeddedEnvironmentActivationInteraction
     extends ConstrainedDegenerateInteraction {
 
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(EmbeddedEnvironmentActivationInteraction.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/interaction/point/PointDisplacementInteraction.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/interaction/point/PointDisplacementInteraction.java
@@ -3,7 +3,8 @@ package fr.ign.cogit.cartagen.agents.diogen.interaction.point;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.cartacom.agent.interfaces.ICartacomAgent;
 import fr.ign.cogit.cartagen.agents.diogen.agent.model.IDiogenAgent;
@@ -30,7 +31,7 @@ public class PointDisplacementInteraction
     extends ConstrainedMultipleTargetsAggregatedInteraction
     implements AggregatedInteraction {
 
-  private static Logger LOGGER = Logger
+  private static Logger LOGGER = LogManager
       .getLogger(PointDisplacementInteraction.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/interactionmodel/constrained/ConstrainedAbstractInteraction.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/interactionmodel/constrained/ConstrainedAbstractInteraction.java
@@ -14,7 +14,8 @@ import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -34,7 +35,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.constraint.GeographicConstraint;
 public abstract class ConstrainedAbstractInteraction
     implements ConstrainedInteraction {
 
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(ConstrainedAbstractInteraction.class.getName());
 
   private static String CONFIGURATION_FILE = "/padawan/interactions.xml";

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/interactionmodel/constrained/ConstrainedDegenerateInteraction.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/interactionmodel/constrained/ConstrainedDegenerateInteraction.java
@@ -6,7 +6,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.diogen.agent.model.IDiogenAgent;
 import fr.ign.cogit.cartagen.agents.diogen.padawan.Environment;
@@ -21,7 +22,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.constraint.GeographicConstraint;
 public abstract class ConstrainedDegenerateInteraction
     extends ConstrainedAbstractInteraction {
 
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(ConstrainedDegenerateInteraction.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/interactionmodel/constrained/ConstrainedMultipleTargetsInteraction.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/interactionmodel/constrained/ConstrainedMultipleTargetsInteraction.java
@@ -5,7 +5,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.diogen.agent.model.IDiogenAgent;
 import fr.ign.cogit.cartagen.agents.diogen.agent.submicro.SubmicroAgent;
@@ -26,7 +27,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.relation.RelationalConstraint;
 public abstract class ConstrainedMultipleTargetsInteraction
     extends ConstrainedAbstractInteraction {
 
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(ConstrainedMultipleTargetsInteraction.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/interactionmodel/constrained/ConstrainedSingleTargetInteraction.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/interactionmodel/constrained/ConstrainedSingleTargetInteraction.java
@@ -6,7 +6,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.diogen.agent.model.IDiogenAgent;
 import fr.ign.cogit.cartagen.agents.diogen.agent.submicro.SubmicroAgent;
@@ -28,7 +29,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.relation.RelationalConstraint;
 public abstract class ConstrainedSingleTargetInteraction
     extends ConstrainedAbstractInteraction {
 
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(ConstrainedSingleTargetInteraction.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/lifecycle/PadawanAdvancedLifeCycle.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/lifecycle/PadawanAdvancedLifeCycle.java
@@ -8,7 +8,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.cartacom.agent.interfaces.ICartacomAgent;
 import fr.ign.cogit.cartagen.agents.core.AgentGeneralisationScheduler;
@@ -42,7 +43,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.state.AgentState;
 
 public class PadawanAdvancedLifeCycle implements AgentLifeCycle {
 
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(PadawanTreeExplorationCycle.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/lifecycle/PadawanBasicLifeCycle.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/lifecycle/PadawanBasicLifeCycle.java
@@ -4,7 +4,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.diogen.agent.model.IDiogenAgent;
 import fr.ign.cogit.cartagen.agents.diogen.interactionmodel.Interaction;
@@ -27,7 +28,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.state.AgentState;
  */
 public class PadawanBasicLifeCycle implements AgentLifeCycle {
 
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(PadawanBasicLifeCycle.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/lifecycle/PadawanTreeExplorationCycle.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/lifecycle/PadawanTreeExplorationCycle.java
@@ -7,7 +7,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.diogen.agent.model.IDiogenAgent;
 import fr.ign.cogit.cartagen.agents.diogen.interactionmodel.Interaction;
@@ -32,7 +33,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.state.AgentState;
 
 public class PadawanTreeExplorationCycle implements AgentLifeCycle {
 
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(PadawanTreeExplorationCycle.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/padawan/Environment.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/padawan/Environment.java
@@ -5,7 +5,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.cartacom.agent.interfaces.ICartacomAgent;
 import fr.ign.cogit.cartagen.agents.diogen.agent.model.GeographicPointAgent;
@@ -20,7 +21,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.agent.IAgent;
 
 public class Environment {
 
-  private static Logger logger = Logger.getLogger(Environment.class.getName());
+  private static Logger logger = LogManager.getLogger(Environment.class.getName());
 
   /**
    * The hostAgent (bidirectional reference, automatically managed).

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/padawan/MatrixParser.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/padawan/MatrixParser.java
@@ -13,7 +13,8 @@ import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -28,7 +29,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.agent.IAgent;
 
 public class MatrixParser {
 
-  private static Logger logger = Logger.getLogger(MatrixParser.class.getName());
+  private static Logger logger = LogManager.getLogger(MatrixParser.class.getName());
 
   public static String ENVIRONMENTS_XML = "/padawan/matrices_routes.xml";
 

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/preprocessing/ComputeRouteSectionGeom.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/preprocessing/ComputeRouteSectionGeom.java
@@ -2,7 +2,8 @@ package fr.ign.cogit.cartagen.agents.diogen.preprocessing;
 
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.diogen.hikingroutes.schema.IRouteSection;
 import fr.ign.cogit.geoxygene.api.spatial.coordgeom.IDirectPosition;
@@ -19,7 +20,7 @@ import fr.ign.cogit.geoxygene.util.algo.JtsAlgorithms;
 
 public class ComputeRouteSectionGeom {
 
-  private static final Logger LOGGER = Logger
+  private static final Logger LOGGER = LogManager
       .getLogger(ComputeRouteSectionGeom.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/preprocessing/ConcatLineStrings.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/preprocessing/ConcatLineStrings.java
@@ -4,7 +4,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.geoxygene.api.spatial.coordgeom.IDirectPosition;
 import fr.ign.cogit.geoxygene.api.spatial.coordgeom.ILineString;
@@ -12,7 +13,7 @@ import fr.ign.cogit.geoxygene.spatial.coordgeom.GM_LineString;
 
 public class ConcatLineStrings {
 
-  private static final Logger LOGGER = Logger.getLogger(ConcatLineStrings.class
+  private static final Logger LOGGER = LogManager.getLogger(ConcatLineStrings.class
       .getName());
 
   private double threshold = 0.5;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/preprocessing/CreateRouteFromRouteSections.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/preprocessing/CreateRouteFromRouteSections.java
@@ -1,13 +1,14 @@
 package fr.ign.cogit.cartagen.agents.diogen.preprocessing;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.diogen.hikingroutes.schema.IRoute;
 import fr.ign.cogit.cartagen.agents.diogen.hikingroutes.schema.IRouteSection;
 
 public class CreateRouteFromRouteSections {
 
-  private static final Logger LOGGER = Logger
+  private static final Logger LOGGER = LogManager
       .getLogger(CreateRouteFromRouteSections.class.getName());
 
   public void createRouteFromOneRouteSection(IRoute route,

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/preprocessing/RouteRoadAssociation.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/preprocessing/RouteRoadAssociation.java
@@ -3,7 +3,8 @@ package fr.ign.cogit.cartagen.agents.diogen.preprocessing;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.diogen.hikingroutes.schema.HikingFactory;
 import fr.ign.cogit.cartagen.agents.diogen.hikingroutes.schema.ICarryingRoadLine;
@@ -22,7 +23,7 @@ import fr.ign.cogit.geoxygene.contrib.cartetopo.CarteTopo;
 
 public class RouteRoadAssociation {
 
-  private static final Logger LOGGER = Logger
+  private static final Logger LOGGER = LogManager
       .getLogger(RouteRoadAssociation.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/schema/EmbeddedDeadEndArea.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/diogen/schema/EmbeddedDeadEndArea.java
@@ -4,7 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.algorithms.network.roads.SlideDeadEnd;
 import fr.ign.cogit.cartagen.core.dataset.CartAGenDoc;
@@ -24,7 +25,7 @@ import fr.ign.cogit.geoxygene.util.algo.CommonAlgorithms;
 public class EmbeddedDeadEndArea extends GeneObjDefault
     implements IEmbeddedDeadEndArea {
 
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(EmbeddedDeadEndArea.class.getName());
 
   private List<IUrbanElement> urbanElements = new ArrayList<IUrbanElement>();

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/GAELDeformableImpl.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/GAELDeformableImpl.java
@@ -8,7 +8,8 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.gael.deformation.submicro.GAELAngle;
 import fr.ign.cogit.cartagen.agents.gael.deformation.submicro.GAELPointSingleton;
@@ -27,7 +28,7 @@ import fr.ign.cogit.geoxygene.feature.FT_FeatureCollection;
  * @author JGaffuri
  */
 public class GAELDeformableImpl implements GAELDeformable {
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(GAELDeformableImpl.class.getName());
 
   private IFeatureCollection<IPointAgent> pointAgents = new FT_FeatureCollection<IPointAgent>();

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/PointAgentDisplacement.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/PointAgentDisplacement.java
@@ -3,7 +3,8 @@
  */
 package fr.ign.cogit.cartagen.agents.gael.deformation;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.geoxygene.util.algo.CommonAlgorithms;
 
@@ -13,7 +14,7 @@ import fr.ign.cogit.geoxygene.util.algo.CommonAlgorithms;
  * 
  */
 public class PointAgentDisplacement {
-  private static Logger logger = Logger.getLogger(PointAgentDisplacement.class
+  private static Logger logger = LogManager.getLogger(PointAgentDisplacement.class
       .getName());
 
   public static void displace(IPointAgent pa, double dx, double dy) {

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/PointAgentDisplacementAction.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/PointAgentDisplacementAction.java
@@ -1,6 +1,7 @@
 package fr.ign.cogit.cartagen.agents.gael.deformation;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.geoxygene.contrib.agents.action.ActionImpl;
 import fr.ign.cogit.geoxygene.contrib.agents.action.ActionProposal;
@@ -14,7 +15,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.constraint.Constraint;
  * 
  */
 public class PointAgentDisplacementAction extends ActionImpl {
-  static Logger logger = Logger
+  static Logger logger = LogManager
       .getLogger(PointAgentDisplacementAction.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/PointAgentImpl.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/PointAgentImpl.java
@@ -7,7 +7,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.AgentUtil;
 import fr.ign.cogit.cartagen.agents.gael.deformation.constraint.SubmicroConstraint;
@@ -52,7 +53,7 @@ import fr.ign.cogit.geoxygene.spatial.geomprim.GM_Point;
  * @author julien Gaffuri 26 juil. 2005
  */
 public class PointAgentImpl extends Agent implements IPointAgent {
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(PointAgentImpl.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/PointAgentLifeCycle.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/PointAgentLifeCycle.java
@@ -3,7 +3,8 @@
  */
 package fr.ign.cogit.cartagen.agents.gael.deformation;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.geoxygene.contrib.agents.action.ActionProposal;
 import fr.ign.cogit.geoxygene.contrib.agents.agent.AgentSatisfactionState;
@@ -15,7 +16,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.lifecycle.AgentLifeCycle;
  * @author jgaffuri
  */
 public class PointAgentLifeCycle implements AgentLifeCycle {
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(PointAgentLifeCycle.class.getName());
 
   private int statesMaxNumber = -1;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/beamsgael/BeamsGAEL.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/beamsgael/BeamsGAEL.java
@@ -3,7 +3,8 @@
  */
 package fr.ign.cogit.cartagen.agents.gael.deformation.beamsgael;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.agent.network.NetworkAgent;
 import fr.ign.cogit.cartagen.agents.gael.deformation.IPointAgent;
@@ -15,7 +16,7 @@ import fr.ign.cogit.cartagen.core.GeneralisationSpecifications;
  * 
  */
 public class BeamsGAEL {
-  private static Logger logger = Logger.getLogger(BeamsGAEL.class.getName());
+  private static Logger logger = LogManager.getLogger(BeamsGAEL.class.getName());
 
   /**
    * the network on which to apply the algorithm

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/constraint/relational/segmentsegment/Join.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/constraint/relational/segmentsegment/Join.java
@@ -3,7 +3,8 @@
  */
 package fr.ign.cogit.cartagen.agents.gael.deformation.constraint.relational.segmentsegment;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.gael.deformation.IPointAgent;
 import fr.ign.cogit.cartagen.agents.gael.deformation.PointAgentDisplacementAction;
@@ -18,7 +19,7 @@ import fr.ign.cogit.geoxygene.api.spatial.coordgeom.IDirectPosition;
  * @author JGaffuri
  */
 public class Join extends SubmicroRelationnalConstraint {
-  private static Logger logger = Logger.getLogger(Join.class.getName());
+  private static Logger logger = LogManager.getLogger(Join.class.getName());
 
   private GAELSegment s1;
 

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/constraint/relational/segmentsegment/MinimalDistance.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/constraint/relational/segmentsegment/MinimalDistance.java
@@ -1,7 +1,8 @@
 // 17 nov. 2005
 package fr.ign.cogit.cartagen.agents.gael.deformation.constraint.relational.segmentsegment;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.gael.deformation.IPointAgent;
 import fr.ign.cogit.cartagen.agents.gael.deformation.PointAgentDisplacementAction;
@@ -18,7 +19,7 @@ import fr.ign.cogit.geoxygene.api.spatial.coordgeom.IDirectPosition;
  * 
  */
 public class MinimalDistance extends SubmicroRelationnalConstraint {
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(MinimalDistance.class.getName());
 
   public double distance;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/decomposers/Decomposers.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/decomposers/Decomposers.java
@@ -1,6 +1,7 @@
 package fr.ign.cogit.cartagen.agents.gael.deformation.decomposers;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.agent.GeographicObjectAgentGeneralisation;
 import fr.ign.cogit.cartagen.agents.gael.deformation.GAELDeformable;
@@ -22,7 +23,7 @@ import fr.ign.cogit.geoxygene.api.spatial.geomroot.IGeometry;
  * 
  */
 public class Decomposers {
-  private static Logger logger = Logger.getLogger(Decomposers.class.getName());
+  private static Logger logger = LogManager.getLogger(Decomposers.class.getName());
 
   /**
    * Decompose the geometry of a polygonal deformable object. This deformable

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/decomposers/GAELMicroSquarring.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/decomposers/GAELMicroSquarring.java
@@ -3,7 +3,8 @@
  */
 package fr.ign.cogit.cartagen.agents.gael.deformation.decomposers;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.action.micro.SquarringAction;
 import fr.ign.cogit.cartagen.agents.core.agent.IMicroAgentGeneralisation;
@@ -21,7 +22,7 @@ import fr.ign.cogit.geoxygene.api.spatial.coordgeom.IPolygon;
  * 
  */
 public class GAELMicroSquarring {
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(SquarringAction.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/decomposers/MesoComponentsDisplacementGAEL.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/decomposers/MesoComponentsDisplacementGAEL.java
@@ -3,7 +3,8 @@
  */
 package fr.ign.cogit.cartagen.agents.gael.deformation.decomposers;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.agent.GeographicObjectAgentGeneralisation;
 import fr.ign.cogit.cartagen.agents.core.agent.MesoAgentGeneralisation;
@@ -24,7 +25,7 @@ import fr.ign.cogit.geoxygene.spatial.geomprim.GM_Point;
  * 
  */
 public class MesoComponentsDisplacementGAEL {
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(MesoComponentsDisplacementGAEL.class.getName());
 
   // importance de la contrainte de proximite objet referents des segments

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/submicro/GAELSegment.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/submicro/GAELSegment.java
@@ -3,7 +3,8 @@ package fr.ign.cogit.cartagen.agents.gael.deformation.submicro;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.AgentUtil;
 import fr.ign.cogit.cartagen.agents.gael.deformation.GAELDeformable;
@@ -34,7 +35,7 @@ import fr.ign.cogit.geoxygene.spatial.coordgeom.GM_LineSegment;
  * 
  */
 public class GAELSegment extends SubMicro implements TriangulationSegment {
-  static Logger logger = Logger.getLogger(GAELSegment.class.getName());
+  static Logger logger = LogManager.getLogger(GAELSegment.class.getName());
 
   private IPointAgent p1;
   private IPointAgent p2;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/triangulation/TriangulationGAEL.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/deformation/triangulation/TriangulationGAEL.java
@@ -3,7 +3,8 @@ package fr.ign.cogit.cartagen.agents.gael.deformation.triangulation;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.gael.deformation.GAELDeformable;
 import fr.ign.cogit.cartagen.agents.gael.deformation.submicro.GAELSegment;
@@ -18,7 +19,7 @@ import fr.ign.cogit.geoxygene.api.spatial.geomroot.IGeometry;
  * @author Gaffuri
  */
 public class TriangulationGAEL {
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(TriangulationGAEL.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/field/HydroSectionDeformation.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/field/HydroSectionDeformation.java
@@ -3,7 +3,8 @@
  */
 package fr.ign.cogit.cartagen.agents.gael.field;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.AgentSpecifications;
 import fr.ign.cogit.cartagen.agents.core.agent.IHydroSectionAgent;
@@ -16,7 +17,7 @@ import fr.ign.cogit.cartagen.core.GeneralisationSpecifications;
  * 
  */
 public class HydroSectionDeformation {
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(HydroSectionDeformation.class.getName());
 
   public static void compute(IHydroSectionAgent tr,

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/field/agent/FieldAgent.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/field/agent/FieldAgent.java
@@ -18,7 +18,7 @@ import fr.ign.cogit.geoxygene.contrib.agents.state.GeographicAgentState;
  * 
  */
 public abstract class FieldAgent extends GeographicAgentGeneralisation {
-  // private static Logger logger = Logger.getLogger(FieldAgent.class);
+  // private static Logger logger = LogManager.getLogger(FieldAgent.class);
 
   public FieldAgent() {
     super();

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/field/agent/partition/PartitionFieldAgent.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/field/agent/partition/PartitionFieldAgent.java
@@ -3,7 +3,8 @@
  */
 package fr.ign.cogit.cartagen.agents.gael.field.agent.partition;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.AgentUtil;
 import fr.ign.cogit.cartagen.agents.gael.field.agent.FieldAgent;
@@ -18,7 +19,7 @@ import fr.ign.cogit.geoxygene.spatial.geomprim.GM_Point;
  * @author julien Gaffuri 1 sept. 2008
  */
 public abstract class PartitionFieldAgent extends FieldAgent {
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(PartitionFieldAgent.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/field/agent/partition/landuse/LandUseFieldAgent.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/field/agent/partition/landuse/LandUseFieldAgent.java
@@ -1,12 +1,13 @@
 package fr.ign.cogit.cartagen.agents.gael.field.agent.partition.landuse;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.gael.field.agent.partition.PartitionFieldAgent;
 import fr.ign.cogit.cartagen.core.genericschema.IGeneObj;
 
 public final class LandUseFieldAgent extends PartitionFieldAgent {
-  static Logger logger = Logger.getLogger(LandUseFieldAgent.class.getName());
+  static Logger logger = LogManager.getLogger(LandUseFieldAgent.class.getName());
 
   private IGeneObj geneObj = null;
 

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/field/agent/relief/ContourLineAgent.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/field/agent/relief/ContourLineAgent.java
@@ -15,7 +15,7 @@ import fr.ign.cogit.geoxygene.schemageo.api.support.champContinu.ChampContinu;
  * @author julien Gaffuri
  */
 public class ContourLineAgent extends MicroAgentGeneralisation {
-  // private static Logger logger = Logger.getLogger(CourbeDeNiveau.class);
+  // private static Logger logger = LogManager.getLogger(CourbeDeNiveau.class);
 
   @Override
   public IContourLine getFeature() {

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/field/agent/relief/DEMPixelAgent.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/field/agent/relief/DEMPixelAgent.java
@@ -3,7 +3,8 @@
  */
 package fr.ign.cogit.cartagen.agents.gael.field.agent.relief;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.agent.MicroAgentGeneralisation;
 import fr.ign.cogit.cartagen.core.genericschema.relief.IDEMPixel;
@@ -13,7 +14,7 @@ import fr.ign.cogit.geoxygene.api.spatial.geomprim.IPoint;
  * @author julien Gaffuri 16 déc. 2008
  */
 public class DEMPixelAgent extends MicroAgentGeneralisation {
-  static Logger logger = Logger.getLogger(DEMPixelAgent.class);
+  static Logger logger = LogManager.getLogger(DEMPixelAgent.class);
 
   @Override
   public IDEMPixel getFeature() {

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/field/agent/relief/ReliefFieldAgent.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/field/agent/relief/ReliefFieldAgent.java
@@ -6,7 +6,8 @@ package fr.ign.cogit.cartagen.agents.gael.field.agent.relief;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.AgentSpecifications;
 import fr.ign.cogit.cartagen.agents.gael.deformation.GAELDeformable;
@@ -28,7 +29,7 @@ import fr.ign.cogit.geoxygene.util.index.Tiling;
  * @author julien Gaffuri
  */
 public final class ReliefFieldAgent extends FieldAgent {
-  private static Logger logger = Logger.getLogger(ReliefFieldAgent.class);
+  private static Logger logger = LogManager.getLogger(ReliefFieldAgent.class);
 
   private IReliefField geneObj = null;
 

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/field/agent/relief/SpotHeightAgent.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/field/agent/relief/SpotHeightAgent.java
@@ -3,7 +3,8 @@
  */
 package fr.ign.cogit.cartagen.agents.gael.field.agent.relief;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.agent.MicroAgentGeneralisation;
 import fr.ign.cogit.cartagen.agents.gael.deformation.PointAgentImpl;
@@ -16,7 +17,7 @@ import fr.ign.cogit.geoxygene.api.spatial.geomprim.IPoint;
  * 
  */
 public class SpotHeightAgent extends MicroAgentGeneralisation {
-  static Logger logger = Logger.getLogger(SpotHeightAgent.class.getName());
+  static Logger logger = LogManager.getLogger(SpotHeightAgent.class.getName());
 
   @Override
   public ISpotHeight getFeature() {

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/field/relation/hydrofield/HydroSectionOutflowRelation.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/agents/gael/field/relation/hydrofield/HydroSectionOutflowRelation.java
@@ -3,7 +3,8 @@
  */
 package fr.ign.cogit.cartagen.agents.gael.field.relation.hydrofield;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.AgentUtil;
 import fr.ign.cogit.cartagen.agents.core.agent.IHydroSectionAgent;
@@ -17,7 +18,7 @@ import fr.ign.cogit.cartagen.core.dataset.CartAGenDoc;
  * 
  */
 public class HydroSectionOutflowRelation extends ObjectFieldRelation {
-  static Logger logger = Logger
+  static Logger logger = LogManager
       .getLogger(HydroSectionOutflowRelation.class.getName());
 
   // la moyenne des q des segments ponderee par longueur

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/block/BuildingsAggregation.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/block/BuildingsAggregation.java
@@ -14,7 +14,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 
-import com.vividsolutions.jts.operation.buffer.BufferParameters;
+import org.locationtech.jts.operation.buffer.BufferParameters;
 
 import fr.ign.cogit.cartagen.core.dataset.CartAGenDoc;
 import fr.ign.cogit.cartagen.core.genericschema.urban.IBuilding;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/block/deletion/BuildingDeletionOverlap.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/block/deletion/BuildingDeletionOverlap.java
@@ -19,7 +19,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.core.genericschema.urban.IUrbanBlock;
 import fr.ign.cogit.cartagen.core.genericschema.urban.IUrbanElement;
@@ -40,7 +41,7 @@ import fr.ign.cogit.geoxygene.feature.FT_FeatureCollection;
  */
 public class BuildingDeletionOverlap {
 
-  private static Logger LOGGER = Logger
+  private static Logger LOGGER = LogManager
       .getLogger(BuildingDeletionOverlap.class);
 
   private double minimumRate = 0.4;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/block/deletion/BuildingDeletionPromethee.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/block/deletion/BuildingDeletionPromethee.java
@@ -16,7 +16,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.core.GeneralisationSpecifications;
 import fr.ign.cogit.cartagen.core.Legend;
@@ -47,7 +48,7 @@ import fr.ign.cogit.geoxygene.schemageo.api.bati.Ilot;
  */
 public class BuildingDeletionPromethee {
 
-  private static Logger LOGGER = Logger
+  private static Logger LOGGER = LogManager
       .getLogger(BuildingDeletionPromethee.class);
 
   private Collection<PrometheeCriterion> criteria;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/block/displacement/BuildingDisplacementRandom.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/block/displacement/BuildingDisplacementRandom.java
@@ -14,7 +14,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.core.GeneralisationSpecifications;
 import fr.ign.cogit.cartagen.core.Legend;
@@ -51,7 +52,7 @@ import fr.ign.cogit.geoxygene.util.algo.CommonAlgorithms;
  * 
  */
 public class BuildingDisplacementRandom {
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(BuildingDisplacementRandom.class.getName());
 
   private static double facteurLongueurDeplacement = 2;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/block/displacement/BuildingDisplacementRuas.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/block/displacement/BuildingDisplacementRuas.java
@@ -7,8 +7,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.logging.Logger;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.LineString;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.LineString;
 
 import fr.ign.cogit.cartagen.common.triangulation.Triangulation;
 import fr.ign.cogit.cartagen.core.GeneralisationSpecifications;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/facilities/AirportTypification.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/facilities/AirportTypification.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 
-import com.vividsolutions.jts.geom.Geometry;
+import org.locationtech.jts.geom.Geometry;
 
 import fr.ign.cogit.cartagen.algorithms.polygon.Skeletonize;
 import fr.ign.cogit.cartagen.core.dataset.CartAGenDataSet;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/landuse/LanduseSimplification.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/landuse/LanduseSimplification.java
@@ -19,8 +19,8 @@ import java.util.Map;
 import java.util.Stack;
 import java.util.logging.Logger;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.Polygon;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.Polygon;
 
 import fr.ign.cogit.geoxygene.api.feature.IFeature;
 import fr.ign.cogit.geoxygene.api.feature.IFeatureCollection;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/network/ConstrainedZonesDrivenDisplacementAlgo.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/network/ConstrainedZonesDrivenDisplacementAlgo.java
@@ -15,7 +15,8 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.cartacom.CartacomSpecifications;
 import fr.ign.cogit.cartagen.agents.cartacom.agent.interfaces.ISmallCompactAgent;
@@ -43,7 +44,7 @@ public class ConstrainedZonesDrivenDisplacementAlgo {
   /**
    * Logger for this class
    */
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(ConstrainedZonesDrivenDisplacementAlgo.class.getName());
 
   // Public fields //

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/network/RiverNetworkSelection.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/network/RiverNetworkSelection.java
@@ -5,7 +5,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.core.dataset.CartAGenDoc;
 import fr.ign.cogit.cartagen.core.genericschema.IGeneObj;
@@ -18,7 +19,7 @@ import fr.ign.cogit.geoxygene.schemageo.api.support.reseau.ArcReseau;
 
 public class RiverNetworkSelection {
 
-    private static Logger logger = Logger
+    private static Logger logger = LogManager
             .getLogger(RiverNetworkSelection.class);
 
     private RiverStrokesNetwork net;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/network/roads/EliminateTownDeadEnds.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/network/roads/EliminateTownDeadEnds.java
@@ -2,7 +2,8 @@ package fr.ign.cogit.cartagen.algorithms.network.roads;
 
 import java.util.HashSet;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.core.genericschema.network.INetworkSection;
 import fr.ign.cogit.cartagen.core.genericschema.urban.IUrbanBlock;
@@ -13,7 +14,7 @@ import fr.ign.cogit.geoxygene.api.spatial.coordgeom.IDirectPosition;
 
 public class EliminateTownDeadEnds {
 
-  private static Logger logger = Logger.getLogger(EliminateTownDeadEnds.class);
+  private static Logger logger = LogManager.getLogger(EliminateTownDeadEnds.class);
 
   /**
    * The street network

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/network/roads/SlideDeadEnd.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/network/roads/SlideDeadEnd.java
@@ -3,7 +3,8 @@ package fr.ign.cogit.cartagen.algorithms.network.roads;
 import java.util.HashMap;
 import java.util.Iterator;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.core.genericschema.IGeneObj;
 import fr.ign.cogit.cartagen.core.genericschema.network.INetworkNode;
@@ -22,7 +23,7 @@ import fr.ign.cogit.geoxygene.util.algo.geomstructure.Vector2D;
 
 public class SlideDeadEnd {
 
-  private static Logger logger = Logger.getLogger(SlideDeadEnd.class.getName());
+  private static Logger logger = LogManager.getLogger(SlideDeadEnd.class.getName());
 
   /**
    * The dead end group the algorithm has to slide

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/points/DelaunayNonConvexHull.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/points/DelaunayNonConvexHull.java
@@ -14,7 +14,8 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.common.triangulation.Triangulation;
 import fr.ign.cogit.cartagen.graph.triangulation.TriangulationPoint;
@@ -37,7 +38,7 @@ import fr.ign.cogit.geoxygene.spatial.coordgeom.GM_Polygon;
  * 
  */
 public class DelaunayNonConvexHull {
-  private final static Logger logger = Logger
+  private final static Logger logger = LogManager
       .getLogger(DelaunayNonConvexHull.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/points/PointDisplacement.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/points/PointDisplacement.java
@@ -12,7 +12,8 @@ package fr.ign.cogit.cartagen.algorithms.points;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.core.genericschema.IGeneObj;
 import fr.ign.cogit.cartagen.core.genericschema.IGeneObjPoint;
@@ -35,7 +36,7 @@ import fr.ign.cogit.geoxygene.spatial.coordgeom.DirectPosition;
  * 
  */
 public class PointDisplacement {
-	private static Logger logger = Logger.getLogger(PointDisplacement.class.getName());
+	private static Logger logger = LogManager.getLogger(PointDisplacement.class.getName());
 
 	private double facteurLongueurDeplacement = 2;
 	private int nbIterations = 5;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/polygon/EnlargeThinPart.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/polygon/EnlargeThinPart.java
@@ -5,13 +5,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryCollection;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.LineString;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.triangulate.DelaunayTriangulationBuilder;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryCollection;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.triangulate.DelaunayTriangulationBuilder;
 
 import fr.ign.cogit.geoxygene.api.spatial.coordgeom.IDirectPosition;
 import fr.ign.cogit.geoxygene.api.spatial.coordgeom.IDirectPositionList;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/polygon/PolygonAggregation.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/polygon/PolygonAggregation.java
@@ -12,7 +12,8 @@ package fr.ign.cogit.cartagen.algorithms.polygon;
 import java.util.HashMap;
 import java.util.Iterator;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.geoxygene.api.spatial.coordgeom.IDirectPosition;
 import fr.ign.cogit.geoxygene.api.spatial.coordgeom.IDirectPositionList;
@@ -26,7 +27,7 @@ import fr.ign.cogit.geoxygene.util.algo.geomstructure.Segment;
 
 public class PolygonAggregation {
 
-  private static Logger logger = Logger.getLogger(PolygonAggregation.class);
+  private static Logger logger = LogManager.getLogger(PolygonAggregation.class);
   private IPolygon polygon1, polygon2;
 
   public PolygonAggregation(IPolygon polygon1, IPolygon polygon2) {

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/polygon/PolygonSquaring.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/polygon/PolygonSquaring.java
@@ -9,7 +9,8 @@
  ******************************************************************************/
 package fr.ign.cogit.cartagen.algorithms.polygon;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.geoxygene.api.spatial.AbstractGeomFactory;
 import fr.ign.cogit.geoxygene.api.spatial.coordgeom.IDirectPosition;
@@ -28,7 +29,7 @@ import fr.ign.cogit.geoxygene.spatial.geomengine.GeometryEngine;
  */
 public class PolygonSquaring {
 
-  private static final Logger logger = Logger.getLogger(PolygonSquaring.class);
+  private static final Logger logger = LogManager.getLogger(PolygonSquaring.class);
 
   private int nb_edges;
   private IDirectPositionList points;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/polygon/SquareAlignPolygons.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/polygon/SquareAlignPolygons.java
@@ -4,8 +4,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import Jama.Matrix;
 import fr.ign.cogit.geoxygene.api.spatial.AbstractGeomFactory;
@@ -20,6 +21,7 @@ import fr.ign.cogit.geoxygene.spatial.geomengine.GeometryEngine;
 import fr.ign.cogit.geoxygene.util.algo.geomstructure.Vector2D;
 import fr.ign.cogit.geoxygene.util.conversion.ParseException;
 import fr.ign.cogit.geoxygene.util.conversion.WktGeOxygene;
+import org.apache.logging.log4j.core.config.Configurator;
 
 /**
  * Implementation of an algorithm to try to square polygons i.e when angles are
@@ -32,7 +34,7 @@ import fr.ign.cogit.geoxygene.util.conversion.WktGeOxygene;
 
 public class SquareAlignPolygons {
 
-  private static final Logger logger = Logger.getLogger(SquareAlignPolygons.class);
+  private static final Logger logger = LogManager.getLogger(SquareAlignPolygons.class);
 
   private IDirectPositionList points; // P0..Pn Q0..Qm.. Z0..Zp
   private List<int[]> indicesRightAngles; // n-1, n, n+1
@@ -527,7 +529,7 @@ public class SquareAlignPolygons {
   }
 
   public static void main(String[] args) throws ParseException {
-    SquareAlignPolygons.logger.setLevel(Level.OFF);
+    Configurator.setLevel(logger.getName(), Level.OFF);
     String poly = "POLYGON((339810.23176300001796335 7642898.97540399990975857,339825.85329399997135624 7642891.98611100018024445,339825.24993900000117719 7642890.42239999957382679,339826.96127000002888963 7642888.81250800006091595,339824.48684899997897446 7642882.04569400008767843,339822.63982699997723103 7642882.6473599998280406,339821.41962499998044223 7642880.1152379997074604,339805.85743199998978525 7642887.29528400022536516,339810.23176300001796335 7642898.97540399990975857))";
     IPolygon pol0 = (IPolygon) WktGeOxygene.makeGeOxygene(poly);
     poly = "POLYGON((339822.98888800002168864 7642872.4665329996496439,339819.41837899998063222 7642862.75993799977004528,339814.07412300002761185 7642864.54277199972420931,339811.56089000002248213 7642857.55325200036168098,339813.0901999999769032 7642857.02936599962413311,339809.87812700000358745 7642848.08210800029337406,339799.22233900002902374 7642851.85121299978345633,339802.0865639999974519 7642860.31517800036817789,339804.42946900002425537 7642867.23689999990165234,339800.57982099999208003 7642868.71306999959051609,339804.0712000000057742 7642879.3496679998934269,339822.98888800002168864 7642872.4665329996496439))";

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/polygon/SquarePolygonLS.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/polygon/SquarePolygonLS.java
@@ -12,7 +12,8 @@ package fr.ign.cogit.cartagen.algorithms.polygon;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import Jama.Matrix;
 import fr.ign.cogit.geoxygene.api.spatial.AbstractGeomFactory;
@@ -36,7 +37,7 @@ import fr.ign.cogit.geoxygene.util.conversion.WktGeOxygene;
  */
 public class SquarePolygonLS {
 
-  private static final Logger logger = Logger.getLogger(SquarePolygonLS.class);
+  private static final Logger logger = LogManager.getLogger(SquarePolygonLS.class);
 
   private IDirectPositionList points;
   private int nb_edges;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/polygon/SquarePolygonQR.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/polygon/SquarePolygonQR.java
@@ -18,7 +18,8 @@ import org.apache.commons.math3.linear.Array2DRowRealMatrix;
 import org.apache.commons.math3.linear.MatrixUtils;
 import org.apache.commons.math3.linear.QRDecomposition;
 import org.apache.commons.math3.linear.RealMatrix;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.geoxygene.api.spatial.AbstractGeomFactory;
 import fr.ign.cogit.geoxygene.api.spatial.coordgeom.IDirectPosition;
@@ -40,7 +41,7 @@ import fr.ign.cogit.geoxygene.util.conversion.WktGeOxygene;
  * 
  */
 public class SquarePolygonQR {
-  private static final Logger logger = Logger.getLogger(SquarePolygonQR.class);
+  private static final Logger logger = LogManager.getLogger(SquarePolygonQR.class);
 
   private IDirectPositionList points;
   private int nb_edges;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/polygon/VisvalingamWhyatt.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/polygon/VisvalingamWhyatt.java
@@ -13,8 +13,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Triangle;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Triangle;
 
 import fr.ign.cogit.geoxygene.api.feature.IFeature;
 import fr.ign.cogit.geoxygene.api.feature.IFeatureCollection;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/section/CollapseDualCarriageways.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/section/CollapseDualCarriageways.java
@@ -7,7 +7,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.common.triangulation.Triangulation;
 import fr.ign.cogit.cartagen.core.dataset.CartAGenDoc;
@@ -44,7 +45,7 @@ import fr.ign.cogit.geoxygene.util.algo.CommonAlgorithms;
 
 public class CollapseDualCarriageways {
     @SuppressWarnings("unused")
-    private static Logger logger = Logger
+    private static Logger logger = LogManager
             .getLogger(CollapseDualCarriageways.class.getName());
 
     // Importance of roads that will be collapsed

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/section/InflectionPoints.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/section/InflectionPoints.java
@@ -15,7 +15,8 @@ package fr.ign.cogit.cartagen.algorithms.section;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.geoxygene.api.spatial.coordgeom.IDirectPosition;
 import fr.ign.cogit.geoxygene.api.spatial.coordgeom.ILineString;
@@ -30,7 +31,7 @@ import fr.ign.cogit.geoxygene.spatial.coordgeom.DirectPositionList;
  */
 
 public class InflectionPoints {
-  private static Logger logger = Logger.getLogger(InflectionPoints.class
+  private static Logger logger = LogManager.getLogger(InflectionPoints.class
       .getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/section/LineCurvatureSmoothing.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/section/LineCurvatureSmoothing.java
@@ -12,12 +12,13 @@
  */
 package fr.ign.cogit.cartagen.algorithms.section;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.LineString;
-import com.vividsolutions.jts.simplify.DouglasPeuckerSimplifier;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.simplify.DouglasPeuckerSimplifier;
 
 import fr.ign.cogit.cartagen.core.GeneralisationSpecifications;
 import fr.ign.cogit.cartagen.core.Legend;
@@ -38,7 +39,7 @@ import fr.ign.cogit.geoxygene.util.algo.CommonAlgorithms;
  */
 
 public class LineCurvatureSmoothing {
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(LineCurvatureSmoothing.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/section/LineGaussianSmoothing.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/section/LineGaussianSmoothing.java
@@ -12,11 +12,12 @@
  */
 package fr.ign.cogit.cartagen.algorithms.section;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.simplify.DouglasPeuckerSimplifier;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.simplify.DouglasPeuckerSimplifier;
 
 import fr.ign.cogit.cartagen.core.GeneralisationSpecifications;
 import fr.ign.cogit.cartagen.core.genericschema.network.INetworkSection;
@@ -38,7 +39,7 @@ import fr.ign.cogit.geoxygene.util.algo.geometricAlgorithms.LineDensification;
  */
 
 public class LineGaussianSmoothing {
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(LineGaussianSmoothing.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/section/PointsCharac.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/algorithms/section/PointsCharac.java
@@ -30,7 +30,7 @@ import fr.ign.cogit.geoxygene.spatial.coordgeom.DirectPositionList;
  */
 
 public class PointsCharac {
-  // private static Logger logger = Logger.getLogger(PointsCharac.class
+  // private static Logger logger = LogManager.getLogger(PointsCharac.class
   // .getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/collagen/enrichment/relations/BuildingRoadRelativeOrientRelation.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/collagen/enrichment/relations/BuildingRoadRelativeOrientRelation.java
@@ -1,6 +1,6 @@
 package fr.ign.cogit.cartagen.collagen.enrichment.relations;
 
-import com.vividsolutions.jts.geom.Geometry;
+import org.locationtech.jts.geom.Geometry;
 
 import fr.ign.cogit.cartagen.collagen.resources.ontology.GeographicRelation;
 import fr.ign.cogit.cartagen.core.genericschema.IGeneObj;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/collagen/processes/implementation/RuralAGENTProcess.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/collagen/processes/implementation/RuralAGENTProcess.java
@@ -4,7 +4,8 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.agents.core.AgentGeneralisationScheduler;
 import fr.ign.cogit.cartagen.agents.core.AgentUtil;
@@ -41,7 +42,7 @@ import fr.ign.cogit.geoxygene.util.index.Tiling;
 public class RuralAGENTProcess extends GeneralisationProcess
     implements StoppableProcess {
 
-  private static Logger LOGGER = Logger.getLogger(RuralAGENTProcess.class);
+  private static Logger LOGGER = LogManager.getLogger(RuralAGENTProcess.class);
 
   private AgentObserver observer;
 

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/collagen/resources/specs/constraints/ConstraintDatabase.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/collagen/resources/specs/constraints/ConstraintDatabase.java
@@ -12,7 +12,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.xerces.dom.DocumentImpl;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.IRI;
@@ -543,7 +543,7 @@ public class ConstraintDatabase {
       exprElem.appendChild(classeElem);
       Element motElem = xmlDoc.createElement("keyword");
       n = xmlDoc.createTextNode(
-          StringEscapeUtils.escapeXml(expr.getKeyWord().toShortcut()));
+          StringEscapeUtils.escapeXml11(expr.getKeyWord().toShortcut()));
       motElem.appendChild(n);
       exprElem.appendChild(motElem);
       if (expr.getClass().equals(ThreshExpressionType.class)
@@ -601,7 +601,7 @@ public class ConstraintDatabase {
           reqElem.appendChild(uniteElem);
           Element opeElem = xmlDoc.createElement("operator");
           n = xmlDoc.createTextNode(
-              StringEscapeUtils.escapeXml(r.getOperator().toShortcut()));
+              StringEscapeUtils.escapeXml11(r.getOperator().toShortcut()));
           opeElem.appendChild(n);
           reqElem.appendChild(opeElem);
           critElem.appendChild(reqElem);
@@ -653,7 +653,7 @@ public class ConstraintDatabase {
       exprElem.appendChild(classeElem);
       Element motElem = xmlDoc.createElement("keyword");
       n = xmlDoc.createTextNode(
-          StringEscapeUtils.escapeXml(expr.getKeyWord().toShortcut()));
+          StringEscapeUtils.escapeXml11(expr.getKeyWord().toShortcut()));
       motElem.appendChild(n);
       exprElem.appendChild(motElem);
       if (expr.getClass().equals(ThreshExpressionType.class)
@@ -711,7 +711,7 @@ public class ConstraintDatabase {
           reqElem.appendChild(uniteElem);
           Element opeElem = xmlDoc.createElement("operator");
           n = xmlDoc.createTextNode(
-              StringEscapeUtils.escapeXml(r.getOperator().toShortcut()));
+              StringEscapeUtils.escapeXml11(r.getOperator().toShortcut()));
           opeElem.appendChild(n);
           reqElem.appendChild(opeElem);
           critElem.appendChild(reqElem);
@@ -763,7 +763,7 @@ public class ConstraintDatabase {
       exprElem.appendChild(classeElem);
       Element motElem = xmlDoc.createElement("keyword");
       n = xmlDoc.createTextNode(
-          StringEscapeUtils.escapeXml(expr.getKeyWord().toShortcut()));
+          StringEscapeUtils.escapeXml11(expr.getKeyWord().toShortcut()));
       motElem.appendChild(n);
       exprElem.appendChild(motElem);
       if (expr.getClass().equals(ThreshExpressionType.class)
@@ -827,7 +827,7 @@ public class ConstraintDatabase {
           reqElem.appendChild(uniteElem);
           Element opeElem = xmlDoc.createElement("operator");
           n = xmlDoc.createTextNode(
-              StringEscapeUtils.escapeXml(r.getOperator().toShortcut()));
+              StringEscapeUtils.escapeXml11(r.getOperator().toShortcut()));
           opeElem.appendChild(n);
           reqElem.appendChild(opeElem);
           critElem.appendChild(reqElem);
@@ -887,7 +887,7 @@ public class ConstraintDatabase {
       exprElem.appendChild(classeElem);
       Element motElem = xmlDoc.createElement("keyword");
       n = xmlDoc.createTextNode(
-          StringEscapeUtils.escapeXml(expr.getKeyWord().toShortcut()));
+          StringEscapeUtils.escapeXml11(expr.getKeyWord().toShortcut()));
       motElem.appendChild(n);
       exprElem.appendChild(motElem);
       if (expr.getClass().equals(ThreshExpressionType.class)
@@ -945,7 +945,7 @@ public class ConstraintDatabase {
           reqElem.appendChild(uniteElem);
           Element opeElem = xmlDoc.createElement("operator");
           n = xmlDoc.createTextNode(
-              StringEscapeUtils.escapeXml(r.getOperator().toShortcut()));
+              StringEscapeUtils.escapeXml11(r.getOperator().toShortcut()));
           opeElem.appendChild(n);
           reqElem.appendChild(opeElem);
           critElem.appendChild(reqElem);

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/collagen/resources/specs/constraints/ExpressionType.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/collagen/resources/specs/constraints/ExpressionType.java
@@ -1,6 +1,6 @@
 package fr.ign.cogit.cartagen.collagen.resources.specs.constraints;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.w3c.dom.Element;
 
 import fr.ign.cogit.cartagen.collagen.resources.specs.CharacterValueType;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/collagen/resources/specs/constraints/SelectionCriterion.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/collagen/resources/specs/constraints/SelectionCriterion.java
@@ -5,7 +5,7 @@ import java.util.Set;
 
 import javax.persistence.Entity;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.w3c.dom.Element;
 
 import fr.ign.cogit.cartagen.collagen.resources.ontology.Character;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/collagen/resources/specs/rules/OperationRulesDatabase.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/collagen/resources/specs/rules/OperationRulesDatabase.java
@@ -13,7 +13,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.xerces.dom.DocumentImpl;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.IRI;
@@ -361,7 +361,7 @@ public class OperationRulesDatabase {
         condElem.appendChild(uniteElem);
         Element opeElem = xmlDoc.createElement("operator");
         n = xmlDoc.createTextNode(
-            StringEscapeUtils.escapeXml(p.getOperator().toShortcut()));
+            StringEscapeUtils.escapeXml11(p.getOperator().toShortcut()));
         opeElem.appendChild(n);
         condElem.appendChild(opeElem);
         premElem.appendChild(condElem);

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/common/triangulation/Triangulation.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/common/triangulation/Triangulation.java
@@ -16,7 +16,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.graph.Graph;
 import fr.ign.cogit.cartagen.graph.triangulation.ITriangulation;
@@ -51,7 +52,7 @@ import fr.ign.cogit.geoxygene.util.index.Tiling;
  */
 
 public class Triangulation extends Graph implements ITriangulation {
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(Triangulation.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/continuous/LeastSquaresMorphing.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/continuous/LeastSquaresMorphing.java
@@ -14,7 +14,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import Jama.Matrix;
 import fr.ign.cogit.cartagen.continuous.optcor.OptCorMorphing;
@@ -39,7 +40,7 @@ import fr.ign.cogit.geoxygene.spatial.geomengine.AbstractGeometryEngine;
 public class LeastSquaresMorphing extends NonLinearLeastSquares
     implements ContinuousGeneralisationMethod {
 
-  private static final Logger logger = Logger
+  private static final Logger logger = LogManager
       .getLogger(LeastSquaresMorphing.class);
 
   private ILineString geomIni, geomFinal;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/continuous/discontinuities/DiscontinuitiesMeasure.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/continuous/discontinuities/DiscontinuitiesMeasure.java
@@ -18,7 +18,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import au.com.bytecode.opencsv.CSVWriter;
 import fr.ign.cogit.geoxygene.api.spatial.geomroot.IGeometry;
@@ -32,7 +33,7 @@ import fr.ign.cogit.geoxygene.api.spatial.geomroot.IGeometry;
  */
 public class DiscontinuitiesMeasure {
 
-  private static final Logger logger = Logger
+  private static final Logger logger = LogManager
       .getLogger(DiscontinuitiesMeasure.class);
   private SortedMap<Double, IGeometry> continuousGeoms;
   private Set<LegibilityFunction> legibilityFunctions = new HashSet<>();

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/continuous/optcor/OptCorMorphing.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/continuous/optcor/OptCorMorphing.java
@@ -14,7 +14,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.continuous.ContinuousGeneralisationMethod;
 import fr.ign.cogit.cartagen.continuous.LeastSquaresMorphing;
@@ -47,7 +48,7 @@ import fr.ign.cogit.geoxygene.util.algo.geomstructure.Vector2D;
  */
 public class OptCorMorphing implements ContinuousGeneralisationMethod {
 
-  private static final Logger logger = Logger.getLogger(OptCorMorphing.class);
+  private static final Logger logger = LogManager.getLogger(OptCorMorphing.class);
 
   private ILineString geomIni, geomFinal;
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/GeneralisationSpecifications.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/GeneralisationSpecifications.java
@@ -16,7 +16,8 @@ import java.io.File;
 
 import javax.swing.JOptionPane;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * ensemble de parametres utilises pour la generalisation
@@ -24,7 +25,7 @@ import org.apache.log4j.Logger;
  */
 public final class GeneralisationSpecifications {
   @SuppressWarnings("unused")
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(GeneralisationSpecifications.class.getName());
 
   // les parametres sont en mm carte, ou bien en m terrain

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/SLDUtilCartagen.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/SLDUtilCartagen.java
@@ -12,7 +12,8 @@ package fr.ign.cogit.cartagen.core;
 import java.awt.Color;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.core.dataset.CartAGenDoc;
 import fr.ign.cogit.cartagen.core.genericschema.IGeneObjLin;
@@ -54,7 +55,7 @@ import fr.ign.cogit.geoxygene.util.algo.geometricAlgorithms.GeometryFactory;
 public class SLDUtilCartagen extends SLDUtil {
 
 	@SuppressWarnings("unused")
-	private static Logger logger = Logger.getLogger(SLDUtilCartagen.class.getName());
+	private static Logger logger = LogManager.getLogger(SLDUtilCartagen.class.getName());
 
 	/**
 	 * Gets the symbol width of a linear object from the SLD value for this object.

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/dataset/CartAGenDataSet.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/dataset/CartAGenDataSet.java
@@ -15,7 +15,8 @@ package fr.ign.cogit.cartagen.core.dataset;
 import java.util.Collection;
 import java.util.HashSet;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.core.dataset.geompool.GeometryPool;
 import fr.ign.cogit.cartagen.core.defaultschema.GeneObjDefault;
@@ -100,7 +101,7 @@ import fr.ign.cogit.geoxygene.util.conversion.ShapefileWriter;
  */
 public class CartAGenDataSet extends DataSet {
 	@SuppressWarnings("unused")
-	private static Logger logger = Logger.getLogger(CartAGenDataSet.class.getName());
+	private static Logger logger = LogManager.getLogger(CartAGenDataSet.class.getName());
 
 	/**
 	 * Default constructor

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/dataset/geompool/ColouredFeature.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/dataset/geompool/ColouredFeature.java
@@ -12,7 +12,8 @@ package fr.ign.cogit.cartagen.core.dataset.geompool;
 import java.awt.Color;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.geoxygene.api.spatial.coordgeom.ILineString;
 import fr.ign.cogit.geoxygene.api.spatial.coordgeom.IPolygon;
@@ -49,7 +50,7 @@ public class ColouredFeature extends DefaultFeature {
   // //////////////////////////////////////////
 
   @SuppressWarnings("unused")
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(ColouredFeature.class.getName());
   private static AtomicInteger idCounter = new AtomicInteger();
 

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/dataset/postgis/PostGISConnector.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/dataset/postgis/PostGISConnector.java
@@ -17,7 +17,8 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.postgis.PGgeometry;
 import org.postgresql.PGConnection;
 
@@ -28,7 +29,7 @@ import org.postgresql.PGConnection;
  *
  */
 public class PostGISConnector {
-	private static Logger logger = Logger.getLogger(PostGISLoader.class.getName());
+	private static Logger logger = LogManager.getLogger(PostGISLoader.class.getName());
 
 	private String url;
 

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/dataset/postgis/PostgisDB.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/dataset/postgis/PostgisDB.java
@@ -19,10 +19,11 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Vector;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-import com.vividsolutions.jts.io.WKBReader;
-import com.vividsolutions.jts.io.WKBWriter;
+import org.locationtech.jts.io.WKBReader;
+import org.locationtech.jts.io.WKBWriter;
 
 /**
  * @author JGaffuri
@@ -31,7 +32,7 @@ public class PostgisDB {
   /**
      */
   private static PostgisDB postGISBD = null;
-  static Logger logger = Logger.getLogger(PostgisDB.class.getName());
+  static Logger logger = LogManager.getLogger(PostgisDB.class.getName());
 
   public static PostgisDB get() {
     if (PostgisDB.postGISBD == null) {

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/dataset/shapefile/ShapeFileClass.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/dataset/shapefile/ShapeFileClass.java
@@ -32,7 +32,7 @@ import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 
-import com.vividsolutions.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.GeometryFactory;
 
 import fr.ign.cogit.cartagen.core.dataset.CartAGenDB;
 import fr.ign.cogit.cartagen.core.dataset.GeographicClass;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/dataset/shapefile/ShapeFileLoader.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/dataset/shapefile/ShapeFileLoader.java
@@ -15,14 +15,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.geotools.data.shapefile.dbf.DbaseFileReader;
 import org.geotools.data.shapefile.files.ShpFiles;
 import org.geotools.data.shapefile.shp.ShapefileReader;
 import org.geotools.data.shapefile.shp.ShapefileReader.Record;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
 
 import fr.ign.cogit.cartagen.core.dataset.CartAGenDB;
 import fr.ign.cogit.cartagen.core.dataset.CartAGenDataSet;
@@ -84,7 +85,7 @@ import fr.ign.cogit.geoxygene.util.conversion.WktGeOxygene;
 
 public class ShapeFileLoader {
 
-    private static Logger logger = Logger
+    private static Logger logger = LogManager
             .getLogger(ShapeFileLoader.class.getName());
 
     // ///////////////////////////////////////

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/defaultschema/DefaultCreationFactory.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/defaultschema/DefaultCreationFactory.java
@@ -13,7 +13,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.core.defaultschema.admin.AdminCapital;
 import fr.ign.cogit.cartagen.core.defaultschema.admin.AdminLimit;
@@ -193,7 +194,7 @@ import fr.ign.cogit.geoxygene.schemageo.api.support.reseau.Reseau;
 
 public class DefaultCreationFactory extends AbstractCreationFactory {
 
-	private static Logger logger = Logger.getLogger(DefaultCreationFactory.class.getName());
+	private static Logger logger = LogManager.getLogger(DefaultCreationFactory.class.getName());
 
 	// /////////////////
 	// URBAN

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/defaultschema/GeneObjDefault.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/defaultschema/GeneObjDefault.java
@@ -46,6 +46,7 @@ import fr.ign.cogit.geoxygene.schema.schemaConceptuelISOJeu.AttributeType;
 import fr.ign.cogit.geoxygene.schema.schemaConceptuelISOJeu.FeatureType;
 import fr.ign.cogit.geoxygene.util.ReflectionUtil;
 import fr.ign.cogit.geoxygene.util.algo.CommonAlgorithms;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * @author CDuchene

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/defaultschema/road/RoadLineWithAttributes.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/defaultschema/road/RoadLineWithAttributes.java
@@ -18,7 +18,8 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Transient;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.hibernate.annotations.Type;
 
 import fr.ign.cogit.cartagen.core.GeneralisationLegend;
@@ -48,7 +49,7 @@ import fr.ign.cogit.geoxygene.schemageo.impl.support.reseau.ReseauImpl;
 public class RoadLineWithAttributes extends NetworkSection
         implements IRoadLine {
 
-    private static final Logger logger = Logger
+    private static final Logger logger = LogManager
             .getLogger(RoadLineWithAttributes.class.getName());
 
     /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/defaultschema/urban/Town.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/defaultschema/urban/Town.java
@@ -32,8 +32,8 @@ import javax.persistence.Transient;
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 import org.hibernate.annotations.Type;
 
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.geom.Polygon;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
 
 import fr.ign.cogit.cartagen.core.dataset.CartAGenDataSet;
 import fr.ign.cogit.cartagen.core.dataset.CartAGenDoc;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/defaultschema/urban/UrbanAlignment.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/defaultschema/urban/UrbanAlignment.java
@@ -23,7 +23,7 @@ import javax.persistence.Transient;
 
 import org.hibernate.annotations.Type;
 
-import com.vividsolutions.jts.operation.buffer.BufferParameters;
+import org.locationtech.jts.operation.buffer.BufferParameters;
 
 import fr.ign.cogit.cartagen.core.GeneralisationSpecifications;
 import fr.ign.cogit.cartagen.core.Legend;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/genericschema/AbstractCreationFactory.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/genericschema/AbstractCreationFactory.java
@@ -13,7 +13,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.core.genericschema.admin.IAdminCapital;
 import fr.ign.cogit.cartagen.core.genericschema.admin.IAdminLimit;
@@ -140,7 +141,7 @@ import fr.ign.cogit.geoxygene.schemageo.api.support.reseau.Reseau;
 
 public abstract class AbstractCreationFactory {
 
-	private static Logger logger = Logger.getLogger(AbstractCreationFactory.class.getName());
+	private static Logger logger = LogManager.getLogger(AbstractCreationFactory.class.getName());
 
 	// /////////////////
 	// URBAN

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/persistence/GeOxygeneGeometryUserType.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/core/persistence/GeOxygeneGeometryUserType.java
@@ -16,13 +16,14 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.hibernate.HibernateException;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.usertype.UserType;
 import org.postgis.PGgeometry;
 
-import com.vividsolutions.jts.geom.Geometry;
+import org.locationtech.jts.geom.Geometry;
 
 import fr.ign.cogit.geoxygene.api.spatial.geomaggr.IMultiCurve;
 import fr.ign.cogit.geoxygene.api.spatial.geomaggr.IMultiPoint;
@@ -35,7 +36,7 @@ import fr.ign.cogit.geoxygene.util.conversion.ParseException;
 import fr.ign.cogit.geoxygene.util.conversion.WktGeOxygene;
 
 public class GeOxygeneGeometryUserType implements UserType {
-	static Logger logger = Logger.getLogger(GeOxygeneGeometryUserType.class.getName());
+	static Logger logger = LogManager.getLogger(GeOxygeneGeometryUserType.class.getName());
 	private static final int[] geometryTypes = new int[] { Types.STRUCT };
 
 	@Override

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/osm/schema/OSMShapefileLoader.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/osm/schema/OSMShapefileLoader.java
@@ -23,14 +23,15 @@ import javax.swing.JDialog;
 import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.geotools.data.shapefile.dbf.DbaseFileReader;
 import org.geotools.data.shapefile.files.ShpFiles;
 import org.geotools.data.shapefile.shp.ShapefileReader;
 import org.geotools.data.shapefile.shp.ShapefileReader.Record;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
 
 import fr.ign.cogit.cartagen.core.dataset.CartAGenDB;
 import fr.ign.cogit.cartagen.core.dataset.shapefile.ShapeFileClass;
@@ -48,7 +49,7 @@ import fr.ign.cogit.geoxygene.util.conversion.AdapterFactory;
 
 public class OSMShapefileLoader extends SwingWorker<Void, Void> {
 
-  private Logger logger = Logger.getLogger(OSMShapefileLoader.class.getName());
+  private Logger logger = LogManager.getLogger(OSMShapefileLoader.class.getName());
 
   // the global tags of OSM files
   public static final String TAG_BOUNDS = "bounds";

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/osm/schema/OsmXmlParser.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/osm/schema/OsmXmlParser.java
@@ -26,7 +26,8 @@ import java.util.Set;
 
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
@@ -56,7 +57,7 @@ import fr.ign.cogit.geoxygene.spatial.geomprim.GM_Point;
  */
 public class OsmXmlParser {
 
-  private static final Logger LOGGER = Logger.getLogger(OsmXmlParser.class);
+  private static final Logger LOGGER = LogManager.getLogger(OsmXmlParser.class);
 
   private Set<OSMResource> nodes;
   private Set<OSMResource> ways;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/schematisation/buslinemap/Backtracking.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/schematisation/buslinemap/Backtracking.java
@@ -4,7 +4,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.spatialanalysis.network.StrokeNode;
 
@@ -15,7 +16,7 @@ import fr.ign.cogit.cartagen.spatialanalysis.network.StrokeNode;
  */
 public class Backtracking {
 
-  private static Logger LOGGER = Logger.getLogger(Backtracking.class.getName());
+  private static Logger LOGGER = LogManager.getLogger(Backtracking.class.getName());
 
   /**
    * This function uses a dichotomic approach to solve the CSP problem

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/schematisation/buslinemap/CSPSolver.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/schematisation/buslinemap/CSPSolver.java
@@ -9,7 +9,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.google.common.collect.Iterables;
 
@@ -25,7 +26,7 @@ import utils.Pair;
  */
 public class CSPSolver {
 
-  private static Logger LOGGER = Logger.getLogger(CSPSolver.class.getName());
+  private static Logger LOGGER = LogManager.getLogger(CSPSolver.class.getName());
 
   /**
    * This function solves a CSP problem with 4 possible algorithms

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/schematisation/buslinemap/ProblemConstraints.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/schematisation/buslinemap/ProblemConstraints.java
@@ -7,7 +7,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.google.common.collect.Iterables;
 
@@ -22,7 +23,7 @@ import fr.ign.cogit.cartagen.spatialanalysis.network.StrokeNode;
  */
 public class ProblemConstraints {
 
-  private static Logger LOGGER = Logger
+  private static Logger LOGGER = LogManager
       .getLogger(ProblemConstraints.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/schematisation/buslinemap/RoadStrokeForRoutes.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/schematisation/buslinemap/RoadStrokeForRoutes.java
@@ -11,7 +11,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.persistence.Entity;
 import javax.persistence.Transient;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.core.genericschema.carringrelation.ICarriedObject;
 import fr.ign.cogit.cartagen.core.genericschema.carringrelation.ICarrierNetworkSection;
@@ -33,7 +34,7 @@ import fr.ign.cogit.geoxygene.schemageo.api.support.reseau.NoeudReseau;
 @Entity
 public class RoadStrokeForRoutes extends Stroke {
 
-  private static Logger LOGGER = Logger
+  private static Logger LOGGER = LogManager
       .getLogger(RoadStrokeForRoutes.class.getName());
 
   private static AtomicInteger COUNTER = new AtomicInteger();

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/schematisation/buslinemap/RouteStrokesNetwork.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/schematisation/buslinemap/RouteStrokesNetwork.java
@@ -8,7 +8,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.google.common.collect.Iterables;
 
@@ -30,7 +31,7 @@ import fr.ign.cogit.geoxygene.schemageo.api.support.reseau.NoeudReseau;
  */
 public class RouteStrokesNetwork extends RoadStrokesNetwork {
 
-  private static Logger LOGGER = Logger.getLogger(RouteStrokesNetwork.class
+  private static Logger LOGGER = LogManager.getLogger(RouteStrokesNetwork.class
       .getName());
 
   private Collection<StrokeNode> routeStrokeNodes;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/schematisation/buslinemap/SimulatedAnnealing.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/schematisation/buslinemap/SimulatedAnnealing.java
@@ -5,7 +5,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import utils.Pair;
 
@@ -20,7 +21,7 @@ import fr.ign.cogit.cartagen.spatialanalysis.network.StrokeNode;
  * 
  */
 public class SimulatedAnnealing {
-  private static Logger LOGGER = Logger.getLogger(SimulatedAnnealing.class
+  private static Logger LOGGER = LogManager.getLogger(SimulatedAnnealing.class
       .getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/schematisation/buslinemap/TronconDeRouteItineraireImpl.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/schematisation/buslinemap/TronconDeRouteItineraireImpl.java
@@ -3,7 +3,8 @@ package fr.ign.cogit.cartagen.schematisation.buslinemap;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.core.genericschema.carringrelation.ICarriedObject;
 import fr.ign.cogit.cartagen.core.genericschema.carringrelation.ICarrierNetworkSection;
@@ -20,7 +21,7 @@ import fr.ign.cogit.geoxygene.schemageo.impl.routier.TronconDeRouteImpl;
 public class TronconDeRouteItineraireImpl extends TronconDeRouteImpl
         implements TronconDeRouteItineraire {
 
-    protected static final Logger LOGGER = Logger
+    protected static final Logger LOGGER = LogManager
             .getLogger(TronconDeRouteItineraireImpl.class.getName());
 
     public TronconDeRouteItineraireImpl(Reseau res, boolean estFictif,

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/schematisation/buslinemap/constraintsStaticFunctionsForCSP.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/schematisation/buslinemap/constraintsStaticFunctionsForCSP.java
@@ -10,7 +10,7 @@ package fr.ign.cogit.cartagen.schematisation.buslinemap;
 public class constraintsStaticFunctionsForCSP {
   //
   // private static Logger LOGGER =
-  // Logger.getLogger(constraintsStaticFunctionsForCSP.class.getName());
+  // LogManager.getLogger(constraintsStaticFunctionsForCSP.class.getName());
   //
   // /**
   // * this function returns a node score according the number of crossed roads

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/fields/FieldEnrichment.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/fields/FieldEnrichment.java
@@ -4,7 +4,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.common.triangulation.Triangulation;
 import fr.ign.cogit.cartagen.core.dataset.CartAGenDoc;
@@ -36,7 +37,7 @@ import fr.ign.cogit.geoxygene.util.index.Tiling;
  * 
  */
 public class FieldEnrichment {
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(FieldEnrichment.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/geospace/gridclassification/GridCell.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/geospace/gridclassification/GridCell.java
@@ -6,7 +6,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Vector;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.geoxygene.api.spatial.coordgeom.IDirectPosition;
 import fr.ign.cogit.geoxygene.api.spatial.coordgeom.IDirectPositionList;
@@ -17,7 +18,7 @@ import fr.ign.cogit.geoxygene.spatial.coordgeom.GM_LineString;
 import fr.ign.cogit.geoxygene.spatial.coordgeom.GM_Polygon;
 
 public class GridCell {
-  private final static Logger logger = Logger.getLogger(GridCell.class
+  private final static Logger logger = LogManager.getLogger(GridCell.class
       .getName());
   private RasterGrid grille;// la grille dont fait partie la cellule
   private int ligne, colonne;// coordonnées de la cellule dans la grille

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/geospace/gridclassification/RasterGrid.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/geospace/gridclassification/RasterGrid.java
@@ -13,9 +13,10 @@ import java.util.Iterator;
 import java.util.Stack;
 import java.util.Vector;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-import com.vividsolutions.jts.geom.Geometry;
+import org.locationtech.jts.geom.Geometry;
 
 import fr.ign.cogit.geoxygene.api.feature.IFeature;
 import fr.ign.cogit.geoxygene.api.feature.IFeatureCollection;
@@ -32,7 +33,7 @@ import fr.ign.cogit.geoxygene.util.conversion.JtsGeOxygene;
  *         données
  */
 public abstract class RasterGrid {
-  private final static Logger logger = Logger.getLogger(RasterGrid.class
+  private final static Logger logger = LogManager.getLogger(RasterGrid.class
       .getName());
   private int tailleCellule;// la taille de chaque cellule
   private int radiusCellule;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/measures/BlockTriangulation.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/measures/BlockTriangulation.java
@@ -6,8 +6,8 @@ package fr.ign.cogit.cartagen.spatialanalysis.measures;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
-
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import fr.ign.cogit.cartagen.common.triangulation.Triangulation;
 import fr.ign.cogit.cartagen.core.genericschema.network.INetworkSection;
 import fr.ign.cogit.cartagen.core.genericschema.urban.IBuilding;
@@ -35,7 +35,7 @@ import fr.ign.cogit.geoxygene.util.algo.geometricAlgorithms.CommonAlgorithmsFrom
  * 
  */
 public class BlockTriangulation {
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(BlockTriangulation.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/measures/ProximityBtwPossiblyOverlappingPolygon.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/measures/ProximityBtwPossiblyOverlappingPolygon.java
@@ -1,6 +1,7 @@
 package fr.ign.cogit.cartagen.spatialanalysis.measures;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.geoxygene.api.spatial.coordgeom.ILineString;
 import fr.ign.cogit.geoxygene.api.spatial.coordgeom.IPolygon;
@@ -10,7 +11,7 @@ import fr.ign.cogit.geoxygene.contrib.geometrie.Distances;
 import fr.ign.cogit.geoxygene.util.algo.JtsAlgorithms;
 
 public class ProximityBtwPossiblyOverlappingPolygon {
-  final static Logger logger = Logger
+  final static Logger logger = LogManager
       .getLogger(ProximityBtwPossiblyOverlappingPolygon.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/measures/coalescence/LineCoalescence.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/measures/coalescence/LineCoalescence.java
@@ -12,7 +12,8 @@ package fr.ign.cogit.cartagen.spatialanalysis.measures.coalescence;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.core.Legend;
 import fr.ign.cogit.cartagen.core.genericschema.network.INetworkSection;
@@ -38,7 +39,7 @@ import fr.ign.cogit.geoxygene.util.algo.JtsAlgorithms;
  */
 public class LineCoalescence {
 
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(LineCoalescence.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/measures/congestion/CongestionComputation.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/measures/congestion/CongestionComputation.java
@@ -26,7 +26,7 @@ import fr.ign.cogit.geoxygene.util.algo.CommonAlgorithms;
  */
 public class CongestionComputation {
   // private static Logger logger =
-  // Logger.getLogger(CalculEncombrement.class.getName());
+  // LogManager.getLogger(CalculEncombrement.class.getName());
 
   /**
    */

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/measures/congestion/DeletionCost.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/measures/congestion/DeletionCost.java
@@ -12,7 +12,8 @@
  */
 package fr.ign.cogit.cartagen.spatialanalysis.measures.congestion;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.geoxygene.contrib.graphe.IGraphLinkableFeature;
 
@@ -21,7 +22,7 @@ import fr.ign.cogit.geoxygene.contrib.graphe.IGraphLinkableFeature;
  * 
  */
 public class DeletionCost {
-  private static Logger logger = Logger.getLogger(DeletionCost.class.getName());
+  private static Logger logger = LogManager.getLogger(DeletionCost.class.getName());
 
   /**
    * mesure d'encombrement permettant de choisir le meilleur batiment d'un ilot

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/measures/section/SectionSymbol.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/measures/section/SectionSymbol.java
@@ -9,9 +9,10 @@
  ******************************************************************************/
 package fr.ign.cogit.cartagen.spatialanalysis.measures.section;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-import com.vividsolutions.jts.operation.buffer.BufferParameters;
+import org.locationtech.jts.operation.buffer.BufferParameters;
 
 import fr.ign.cogit.cartagen.core.Legend;
 import fr.ign.cogit.cartagen.core.SLDUtilCartagen;
@@ -29,7 +30,7 @@ import fr.ign.cogit.geoxygene.util.algo.JtsAlgorithms;
 import fr.ign.cogit.geoxygene.util.algo.geometricAlgorithms.CommonAlgorithmsFromCartAGen;
 
 public class SectionSymbol {
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(SectionSymbol.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/network/NetworkEnrichment.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/network/NetworkEnrichment.java
@@ -15,7 +15,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.core.dataset.CartAGenDataSet;
 import fr.ign.cogit.cartagen.core.genericschema.AbstractCreationFactory;
@@ -52,7 +53,7 @@ import fr.ign.cogit.geoxygene.util.index.Tiling;
  * 
  */
 public class NetworkEnrichment {
-    private static Logger logger = Logger
+    private static Logger logger = LogManager
             .getLogger(NetworkEnrichment.class.getName());
 
     /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/network/Stroke.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/network/Stroke.java
@@ -18,7 +18,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.spatialanalysis.network.roads.RoadStrokesNetwork;
 import fr.ign.cogit.cartagen.util.geometry.LineOperations;
@@ -39,7 +40,7 @@ import fr.ign.cogit.geoxygene.spatial.coordgeom.DirectPositionList;
 import fr.ign.cogit.geoxygene.spatial.coordgeom.GM_LineString;
 
 public class Stroke extends AbstractFeature implements Comparable<Stroke> {
-	private static Logger logger = Logger.getLogger(Stroke.class.getName());
+	private static Logger logger = LogManager.getLogger(Stroke.class.getName());
 
 	private StrokesNetwork network;
 

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/network/StrokesNetwork.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/network/StrokesNetwork.java
@@ -14,14 +14,15 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.geoxygene.schema.schemaConceptuelISOJeu.FeatureType;
 import fr.ign.cogit.geoxygene.schemageo.api.support.reseau.ArcReseau;
 
 public class StrokesNetwork {
 
-  private static Logger logger = Logger.getLogger(StrokesNetwork.class
+  private static Logger logger = LogManager.getLogger(StrokesNetwork.class
       .getName());
 
   private Set<Stroke> strokes;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/network/deadendzoning/DeadEndZoning.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/network/deadendzoning/DeadEndZoning.java
@@ -4,7 +4,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.core.genericschema.network.INetworkSection;
 import fr.ign.cogit.cartagen.core.genericschema.network.NetworkSectionType;
@@ -29,7 +30,7 @@ import fr.ign.cogit.geoxygene.util.algo.geometricAlgorithms.morphomaths.Side;
  */
 public class DeadEndZoning {
 
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(DeadEndZoning.class.getName());
   /**
    * The network face geometry in which the zoning is computed (the zoning is

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/network/roads/RoadStructureDetection.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/network/roads/RoadStructureDetection.java
@@ -18,7 +18,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jgrapht.alg.DijkstraShortestPath;
 import org.jgrapht.graph.DefaultWeightedEdge;
 import org.jgrapht.graph.WeightedPseudograph;
@@ -69,7 +70,7 @@ import fr.ign.cogit.geoxygene.util.algo.SmallestSurroundingRectangleComputation;
  */
 public class RoadStructureDetection {
 
-    private static Logger logger = Logger
+    private static Logger logger = LogManager
             .getLogger(RoadStructureDetection.class);
 
     private CarteTopo topoMap;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/network/streets/StreetNetwork.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/network/streets/StreetNetwork.java
@@ -16,7 +16,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jfree.data.statistics.Statistics;
 
 import fr.ign.cogit.cartagen.core.GeneralisationSpecifications;
@@ -67,7 +68,7 @@ public class StreetNetwork extends AbstractFeature {
 
     // All static fields //
     public static String ROAD_TRAFFIC_ATTRIBUTE = "accessWeight";
-    private static Logger logger = Logger
+    private static Logger logger = LogManager
             .getLogger(StreetNetwork.class.getName());
     private static double sMinT = 3250.0;// 1 mm * 1.3 mm map at 1:50 000.
     private static AtomicInteger counter = new AtomicInteger();

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/urban/BlocksComputationPolygonizerJTS.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/urban/BlocksComputationPolygonizerJTS.java
@@ -15,12 +15,12 @@ package fr.ign.cogit.cartagen.spatialanalysis.urban;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.LineString;
-import com.vividsolutions.jts.geom.MultiLineString;
-import com.vividsolutions.jts.geom.Polygon;
-import com.vividsolutions.jts.operation.polygonize.Polygonizer;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.MultiLineString;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.operation.polygonize.Polygonizer;
 
 import fr.ign.cogit.geoxygene.api.spatial.coordgeom.ILineString;
 import fr.ign.cogit.geoxygene.api.spatial.coordgeom.IPolygon;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/urban/CornerBuildings.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/urban/CornerBuildings.java
@@ -11,7 +11,8 @@ package fr.ign.cogit.cartagen.spatialanalysis.urban;
 
 import java.util.HashSet;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.core.Legend;
 import fr.ign.cogit.geoxygene.api.feature.IFeatureCollection;
@@ -45,7 +46,7 @@ public class CornerBuildings {
   // //////////////////////////////////////////
 
   // All static fields //
-  private static Logger LOGGER = Logger.getLogger(CornerBuildings.class);
+  private static Logger LOGGER = LogManager.getLogger(CornerBuildings.class);
 
   // Private fields //
   private Ilot block;

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/urban/EmptySpacesDetection.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/urban/EmptySpacesDetection.java
@@ -9,7 +9,8 @@
  ******************************************************************************/
 package fr.ign.cogit.cartagen.spatialanalysis.urban;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.cartagen.core.dataset.CartAGenDoc;
 import fr.ign.cogit.cartagen.core.genericschema.urban.IUrbanBlock;
@@ -22,7 +23,7 @@ import fr.ign.cogit.geoxygene.util.algo.geometricAlgorithms.morphomaths.Morpholo
 
 public class EmptySpacesDetection {
 
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(EmptySpacesDetection.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/urban/UrbanAreaComputationJTS.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/urban/UrbanAreaComputationJTS.java
@@ -19,13 +19,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.MultiPolygon;
-import com.vividsolutions.jts.geom.Polygon;
-import com.vividsolutions.jts.operation.buffer.BufferParameters;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.operation.buffer.BufferParameters;
 
 import fr.ign.cogit.cartagen.core.genericschema.urban.IBuilding;
 import fr.ign.cogit.cartagen.util.SpatialQuery;
@@ -48,7 +49,7 @@ import fr.ign.cogit.geoxygene.util.conversion.AdapterFactory;
  * 
  */
 public class UrbanAreaComputationJTS {
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(UrbanAreaComputationJTS.class.getName());
 
   /**

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/urban/UrbanEnrichment.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/spatialanalysis/urban/UrbanEnrichment.java
@@ -17,9 +17,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-import com.vividsolutions.jts.operation.buffer.BufferParameters;
+import org.locationtech.jts.operation.buffer.BufferParameters;
 
 import fr.ign.cogit.cartagen.core.GeneralisationSpecifications;
 import fr.ign.cogit.cartagen.core.Legend;
@@ -64,7 +65,7 @@ import fr.ign.cogit.geoxygene.util.index.Tiling;
  * 
  */
 public class UrbanEnrichment {
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(UrbanEnrichment.class.getName());
 
   // Parameters for towns construction

--- a/cartagen-core/src/main/java/fr/ign/cogit/cartagen/util/multicriteriadecision/promethee/PrometheeDecision.java
+++ b/cartagen-core/src/main/java/fr/ign/cogit/cartagen/util/multicriteriadecision/promethee/PrometheeDecision.java
@@ -18,7 +18,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import fr.ign.cogit.geoxygene.util.CollectionsUtil;
 
@@ -30,7 +31,7 @@ import fr.ign.cogit.geoxygene.util.CollectionsUtil;
  */
 public class PrometheeDecision {
 
-  private static Logger logger = Logger
+  private static Logger logger = LogManager
       .getLogger(PrometheeDecision.class.getName());
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
 		<jts.version>1.19.0</jts.version>
-		<log4j.version>1.2.16</log4j.version>
-		<geotools.version>17.2</geotools.version>
+		<log4j.version>2.17.2</log4j.version>
+		<geotools.version>29.0</geotools.version>
 		<jfreechart.version>1.0.13</jfreechart.version>
 		<jgrapht.version>0.9.0</jgrapht.version>
 		<postgresql.version>9.1-901-1.jdbc4</postgresql.version>
@@ -31,7 +31,7 @@
 		<!-- <skip.integration.tests>true</skip.integration.tests> -->
 	</properties>
   
-  	<!-- ======================================================= -->
+	<!-- ======================================================= -->
 	<!-- Build -->
 	<!-- ======================================================= -->
   <build>
@@ -43,7 +43,7 @@
 			<configuration>
 				<compilerVersion>1.8</compilerVersion>
 				<source>1.8</source>
-				<complianceLevel>1.8</complianceLevel>
+
 				<target>1.8</target>
 			</configuration>
 		</plugin>
@@ -54,93 +54,82 @@
 		</plugin>
 	</plugins>
   </build>
-	<repositories>
 
+	<repositories>
 		<repository>
-			<id>geosolutions</id>
-			<name>GeoSolutions libraries repository</name>
-			<url>https://maven.geo-solutions.it/</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
+			<id>osgeo</id>
+			<name>OSGeo Release Repository</name>
+			<url>https://repo.osgeo.org/repository/release/</url>
+			<snapshots><enabled>false</enabled></snapshots>
+			<releases><enabled>true</enabled></releases>
 		</repository>
-       <repository>
-            <id>osgeo</id>
-            <name>OSGeo Release Repository</name>
-            <url>https://repo.osgeo.org/repository/release/</url>
-            <snapshots><enabled>false</enabled></snapshots>
-            <releases><enabled>true</enabled></releases>
-        </repository>
-        <repository>
-	        <id>local-maven-repo</id>
-	        <url>file://${project.basedir}/local-maven-repo</url>
-	    </repository>
+		<repository>
+			<id>local-maven-repo</id>
+			<url>file://${project.basedir}/local-maven-repo</url>
+		</repository>
 	</repositories>
 
 
 	<dependencies>
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
 			<version>${log4j.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>geoxygene-api</artifactId>
-			<version>1.9-SNAPSHOT</version>
+			<version>${geoxygene.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>geoxygene-schemageo</artifactId>
-			<version>1.9-SNAPSHOT</version>
+			<version>${geoxygene.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>geoxygene-feature</artifactId>
-			<version>1.9-SNAPSHOT</version>
+			<version>${geoxygene.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>geoxygene-spatial</artifactId>
-			<version>1.9-SNAPSHOT</version>
+			<version>${geoxygene.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>geoxygene-io</artifactId>
-			<version>1.9-SNAPSHOT</version>
+			<version>${geoxygene.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>geoxygene-filter</artifactId>
-			<version>1.9-SNAPSHOT</version>
+			<version>${geoxygene.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>geoxygene-style</artifactId>
-			<version>1.9-SNAPSHOT</version>
+			<version>${geoxygene.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>fr.ign.cogit</groupId>
 			<artifactId>geoxygene-contrib</artifactId>
-			<version>1.9-SNAPSHOT</version>
+			<version>${geoxygene.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>fr.ign.cogit</groupId>
 			<artifactId>geoxygene-database</artifactId>
-			<version>1.9-SNAPSHOT</version>
+			<version>${geoxygene.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>fr.ign.cogit</groupId>
 			<artifactId>geoxygene-spatialrelation</artifactId>
-			<version>1.9-SNAPSHOT</version>
+			<version>${geoxygene.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.locationtech.jts</groupId>
-			<artifactId>jts</artifactId>
+			<artifactId>jts-core</artifactId>
 			<version>${jts.version}</version>
 		</dependency>
 
@@ -167,38 +156,26 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.swinglabs</groupId>
-			<artifactId>swingx</artifactId>
-			<version>1.6.1</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.jdesktop</groupId>
-			<artifactId>beansbinding</artifactId>
-			<version>1.2.1</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
 			<groupId>net.sourceforge.collections</groupId>
 			<artifactId>collections-generic</artifactId>
 			<version>4.01</version>
 		</dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-entitymanager</artifactId>
-            <version>${hibernate.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-spatial</artifactId>
-            <version>${hibernate.version}</version>
-            <exclusions>
-            	<exclusion>
-            		<artifactId>slf4j-api</artifactId>
-            		<groupId>org.slf4j</groupId>
-            	</exclusion>
-            </exclusions>
-        </dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-entitymanager</artifactId>
+			<version>${hibernate.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-spatial</artifactId>
+			<version>${hibernate.version}</version>
+			<exclusions>
+				<exclusion>
+					<artifactId>slf4j-api</artifactId>
+					<groupId>org.slf4j</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 		<dependency>
 			<groupId>org.geotools</groupId>
 			<artifactId>gt-referencing</artifactId>
@@ -212,11 +189,6 @@
 		<dependency>
 			<groupId>org.geotools</groupId>
 			<artifactId>gt-main</artifactId>
-			<version>${geotools.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.geotools</groupId>
-			<artifactId>gt-api</artifactId>
 			<version>${geotools.version}</version>
 		</dependency>
 		<dependency>
@@ -235,11 +207,11 @@
 			<artifactId>postgresql</artifactId>
 			<version>${postgresql.version}</version>
 		</dependency>
- 	<dependency>
-		    <groupId>net.postgis</groupId>
-		    <artifactId>postgis-jdbc</artifactId>
-		    <version>${postgis.jdbc.version}</version>
- 	</dependency> 
+		<dependency>
+			<groupId>net.postgis</groupId>
+			<artifactId>postgis-jdbc</artifactId>
+			<version>${postgis.jdbc.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>com.opencsv</groupId>
 			<artifactId>opencsv</artifactId>
@@ -251,72 +223,68 @@
 			<version>1.3.04</version>
 		</dependency>
 		<dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis-xerces</artifactId>
-            <version>2.7.1</version>
-        </dependency>
+			<groupId>xml-apis</groupId>
+			<artifactId>xml-apis-xerces</artifactId>
+			<version>2.7.1</version>
+		</dependency>
 		<dependency>
-            <groupId>xerces</groupId>
-            <artifactId>xercesImpl</artifactId>
-            <version>2.12.2</version>
-        </dependency>
-        <dependency>
-            <groupId>com.thoughtworks.xstream</groupId>
-            <artifactId>xstream</artifactId>
-            <version>1.4.19</version>
-        </dependency>
-        <dependency>
+			<groupId>xerces</groupId>
+			<artifactId>xercesImpl</artifactId>
+			<version>2.12.2</version>
+		</dependency>
+		<dependency>
+			<groupId>com.thoughtworks.xstream</groupId>
+			<artifactId>xstream</artifactId>
+			<version>1.4.19</version>
+		</dependency>
+		<dependency>
 			<groupId>jfree</groupId>
 			<artifactId>jfreechart</artifactId>
 			<version>${jfreechart.version}</version>
 		</dependency>
-        <dependency>
-            <groupId>jfree</groupId>
-            <artifactId>jcommon</artifactId>
-            <version>1.0.0</version>
-        </dependency>
-        <dependency>
-            <groupId>java3d</groupId>
-            <artifactId>vecmath</artifactId>
-            <version>1.5.2</version>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.media</groupId>
-            <artifactId>jai_core</artifactId>
-            <version>1.1.3</version>
-        </dependency>
-
-        <dependency>
-        	<groupId>org.jgrapht</groupId>
-        	<artifactId>jgrapht-core</artifactId>
-        	<version>0.9.1</version>
-        </dependency>
 		<dependency>
-      		<groupId>com.github.haifengl</groupId>
-      		<artifactId>smile-core</artifactId>
-      		<version>1.2.0</version>
-		</dependency> 
-		<dependency>
-	    	<groupId>org.slf4j</groupId>
-	    	<artifactId>slf4j-api</artifactId>
-	    	<version>1.7.21</version>
-		</dependency>  
-		<dependency>
-    		<groupId>org.slf4j</groupId>
-    		<artifactId>slf4j-simple</artifactId>
-    		<version>1.7.21</version>
+			<groupId>jfree</groupId>
+			<artifactId>jcommon</artifactId>
+			<version>1.0.0</version>
 		</dependency>
 		<dependency>
-		    <groupId>com.google.guava</groupId>
-		    <artifactId>guava</artifactId>
-		    <version>31.1-jre</version>
+			<groupId>java3d</groupId>
+			<artifactId>vecmath</artifactId>
+			<version>1.5.2</version>
+		</dependency>
+
+		<dependency>
+			<groupId>javax.media</groupId>
+			<artifactId>jai_core</artifactId>
+			<version>1.1.3</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.jgrapht</groupId>
+			<artifactId>jgrapht-core</artifactId>
+			<version>0.9.1</version>
+		</dependency>
+		<dependency>
+			<groupId>com.github.haifengl</groupId>
+			<artifactId>smile-core</artifactId>
+			<version>1.2.0</version>
+		</dependency> 
+
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>31.1-jre</version>
 		</dependency>
 		
 		<dependency>
-		    <groupId>org.apache.commons</groupId>
-		    <artifactId>commons-math3</artifactId>
-		    <version>3.6.1</version>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-math3</artifactId>
+			<version>3.6.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+			<version>1.10.0</version>
 		</dependency>
 		
 		<dependency>


### PR DESCRIPTION
First of all thanks for all the work on this project. The achievable results seem pretty impressive to me.
After I recently read your paper [^1], I wanted to try out this application. Unfortunately, I immediately was confronted by hundreds of errors when trying to compile the application. 

Most of the errors come from
 - extremely outdated dependencies (e.g. JTS) and therefore resulting conflicts
 - missing dependencies: there are so many dependencies not listed

Anyway, this PR provides all the changes I had to apply, to make the build work. 

<hr>

Following is a breakdown of all the required changes: 

##### JTS
- As I already explained in #27 The provided snapshots of GeOxygene in the external-jars folder are using JTS from `org.locationtech.jts`, but CartAGen still uses `com.vividsolutions.jts`. This results in a lot of incompatible type errors.
- The recent commit (3d51010) also does not address this correctly, as the artifact id has to be `jts-core` not `jts`! 
- To accomplish the migration I used the two commands provided in https://github.com/locationtech/jts/blob/master/MIGRATION.md

##### Geotools
- Due to migration of JTS, Geotools has to be upgraded aswell, as the previously used version (17.2) still use JTS from `com.vividsolutions.jts` which is incompatible with GeOxygene as explained above.
 
##### log4j
- log4j 1.2 has long become end of life. I was a bit hesistant to apply this change because it changes a lot of files, but I just could not get it to work using this old version, as I always ran into following error `The import org.apache.log4j cannot be resolved`
- upgrading to log4j and respectively replacing everything with the new API ([ref](https://logging.apache.org/log4j/2.x/manual/migration.html#option-2-convert-your-application-to-the-log4j-2-api-log4j-api)) did work though.
 
#### Missing dependencies
- cartagen:
    - `org.apache.commons/commons-text` for `StringEscapeUtils`
    - `com.google.guava/guava` for `Iterables`
    - `au.com.bytecode/opencsv` for `CSVWriter` (Why is `au.com.bytecode/opencsv` and `com.opencsv/opencsv` being used at the same time in the first place?)
- cartagen-appli:
    - `fr.ign.cogit/carto` and `fr.ign.cogit/ontology` (Also have to make sure that it is not geoxygene-carto and geoxygene-ontology, although the provided jars are named that way. This could use a hint in the installation instructions.)
    - `com.jgoodies/jgoodies-forms`
    - `org.lwjgl.lwjgl/lwjgl`: Here it is important to use version 2.9.1 as more recent versions won't work with CartAGen but instead result in errors such as `java.lang.NoClassDefFoundError: org/lwjgl/LWJGLException`. Don't know what causes this error, but older version works at least.

#### Removed dependencies
To declutter the dependency files a tiny bit I opted to remove some references to packages which did not seem to be used:
- e.g `net.sourceforge.jexcelapi`, `org.slf4j`, `org.swinglabs/swingx`, `org.jdesktop/beansbinding`

#### Additional changes
- the provided snapshots of geoxygene are all 1.10, but CartAGen was still referencing 1.9-SNAPSHOT in a lot of places. This is such an obvious issue, I guess that nobody even bothered to test this before releasing...

Fixes #27
Fixes #28 

[^1]: Guillaume Touya, Imran Lokhat, Cécile Duchêne. CartAGen: an Open Source Research Platform for Map Generalization. International Cartographic Conference 2019, Jul 2019, Tokyo, Japan. pp.1-9, ⟨10.5194/ica-proc-2-134-2019⟩. ⟨hal-02270589⟩](https://hal.science/hal-02270589/)